### PR TITLE
🐛(frontend) improve e2e tests avoiding race condition from mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(frontend) improve e2e tests avoiding race condition from mocks #641
 - 🐛(backend) fix flaky test with search contact #605
 - 🐛(backend) fix flaky test with team access #646
 - 🧑‍💻(dimail) remove 'NoneType: None' log in debug mode

--- a/src/frontend/apps/desk/next-env.d.ts
+++ b/src/frontend/apps/desk/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/src/frontend/apps/e2e/__tests__/app-desk/config.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/config.spec.ts
@@ -60,12 +60,6 @@ test.describe('Config', () => {
     page,
     browserName,
   }) => {
-    await page.goto('/');
-    // Login with a user who has the visibility on the groups should see groups
-    // It's now the backend that decides if the user can see the group menu and they
-    // should be redirected to the groups page in such case
-    await keyCloakSignIn(page, browserName, 'team-administrator');
-
     await page.route('**/api/v1.0/config/', async (route) => {
       const request = route.request();
       if (request.method().includes('GET')) {
@@ -82,6 +76,12 @@ test.describe('Config', () => {
         await route.continue();
       }
     });
+
+    await page.goto('/');
+    // Login with a user who has the visibility on the groups should see groups
+    // It's now the backend that decides if the user can see the group menu and they
+    // should be redirected to the groups page in such case
+    await keyCloakSignIn(page, browserName, 'team-administrator');
 
     await expect(page.locator('menu')).toBeHidden();
 

--- a/src/frontend/apps/e2e/__tests__/app-desk/keyboard-navigation.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/keyboard-navigation.spec.ts
@@ -25,9 +25,9 @@ const payloadGetTeams = {
   ],
 };
 
-const mockApiRequests = (page: Page) => {
-  void page.route('**/teams/?ordering=-created_at', (route) => {
-    void route.fulfill({
+const mockApiRequests = async (page: Page) => {
+  await page.route('**/teams/?ordering=-created_at', async (route) => {
+    await route.fulfill({
       json: payloadGetTeams.results,
     });
   });
@@ -40,10 +40,10 @@ test.describe('Keyboard navigation', () => {
   }) => {
     const page = await browser.newPage();
 
+    await mockApiRequests(page);
+
     await page.goto('/');
     await keyCloakSignIn(page, browserName, 'team-owner-mail-member');
-
-    void mockApiRequests(page);
 
     const header = page.locator('header');
 

--- a/src/frontend/apps/e2e/__tests__/app-desk/mail-domain.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/mail-domain.spec.ts
@@ -142,11 +142,6 @@ test.describe('Mail domain', () => {
   });
 
   test.describe('user is administrator or owner', () => {
-    test.beforeEach(async ({ page, browserName }) => {
-      await page.goto('/');
-      await keyCloakSignIn(page, browserName, 'mail-owner');
-    });
-
     test.describe('mail domain is enabled', () => {
       const mailDomainsFixtures: MailDomain[] = [
         {
@@ -215,8 +210,11 @@ test.describe('Mail domain', () => {
         },
       ];
 
-      test('checks if all tabs are visible', async ({ page }) => {
+      test('checks if all tabs are visible', async ({ page, browserName }) => {
         await interceptCommonApiCalls(page, mailDomainsFixtures);
+
+        await page.goto('/');
+        await keyCloakSignIn(page, browserName, 'mail-owner');
 
         await clickOnMailDomainsNavButton(page);
 
@@ -230,8 +228,12 @@ test.describe('Mail domain', () => {
 
       test('checks all the elements are visible when domain exist but contains no mailboxes', async ({
         page,
+        browserName,
       }) => {
         await interceptCommonApiCalls(page, mailDomainsFixtures);
+
+        await page.goto('/');
+        await keyCloakSignIn(page, browserName, 'mail-owner');
 
         await clickOnMailDomainsNavButton(page);
 
@@ -248,6 +250,7 @@ test.describe('Mail domain', () => {
 
       test('checks all the elements are visible when domain exists and contains 2 pages of mailboxes', async ({
         page,
+        browserName,
       }) => {
         const mailboxesFixtures = {
           domainFr: {
@@ -324,6 +327,9 @@ test.describe('Mail domain', () => {
 
         await interceptApiCalls();
 
+        await page.goto('/');
+        await keyCloakSignIn(page, browserName, 'mail-owner');
+
         await clickOnMailDomainsNavButton(page);
 
         await assertMailDomainUpperElementsAreVisible(page);
@@ -360,8 +366,14 @@ test.describe('Mail domain', () => {
         },
       ];
 
-      test('checks expected elements are visible', async ({ page }) => {
+      test('checks expected elements are visible', async ({
+        page,
+        browserName,
+      }) => {
         await interceptCommonApiCalls(page, mailDomainsFixtures);
+
+        await page.goto('/');
+        await keyCloakSignIn(page, browserName, 'mail-owner');
 
         await clickOnMailDomainsNavButton(page);
 
@@ -404,8 +416,14 @@ test.describe('Mail domain', () => {
         },
       ];
 
-      test('checks expected elements are visible', async ({ page }) => {
+      test('checks expected elements are visible', async ({
+        page,
+        browserName,
+      }) => {
         await interceptCommonApiCalls(page, mailDomainsFixtures);
+
+        await page.goto('/');
+        await keyCloakSignIn(page, browserName, 'mail-owner');
 
         await clickOnMailDomainsNavButton(page);
 
@@ -447,8 +465,14 @@ test.describe('Mail domain', () => {
         },
       ];
 
-      test('checks expected elements are visible', async ({ page }) => {
+      test('checks expected elements are visible', async ({
+        page,
+        browserName,
+      }) => {
         await interceptCommonApiCalls(page, mailDomainsFixtures);
+
+        await page.goto('/');
+        await keyCloakSignIn(page, browserName, 'mail-owner');
 
         await clickOnMailDomainsNavButton(page);
 
@@ -476,11 +500,6 @@ test.describe('Mail domain', () => {
   });
 
   test.describe('user is member', () => {
-    test.beforeEach(async ({ page, browserName }) => {
-      await page.goto('/');
-      await keyCloakSignIn(page, browserName, 'mail-member');
-    });
-
     test.describe('mail domain is enabled', () => {
       const mailDomainsFixtures: MailDomain[] = [
         {
@@ -551,8 +570,12 @@ test.describe('Mail domain', () => {
 
       test('checks all the elements are visible when domain exist but contains no mailboxes', async ({
         page,
+        browserName,
       }) => {
         await interceptCommonApiCalls(page, mailDomainsFixtures);
+
+        await page.goto('/');
+        await keyCloakSignIn(page, browserName, 'mail-member');
 
         await clickOnMailDomainsNavButton(page);
 
@@ -569,6 +592,7 @@ test.describe('Mail domain', () => {
 
       test('checks all the elements are visible when domain exists and contains 2 pages of mailboxes', async ({
         page,
+        browserName,
       }) => {
         const mailboxesFixtures = {
           domainFr: {
@@ -645,6 +669,9 @@ test.describe('Mail domain', () => {
 
         await interceptApiCalls();
 
+        await page.goto('/');
+        await keyCloakSignIn(page, browserName, 'mail-member');
+
         await clickOnMailDomainsNavButton(page);
 
         await assertMailDomainUpperElementsAreVisible(page);
@@ -681,8 +708,14 @@ test.describe('Mail domain', () => {
         },
       ];
 
-      test('checks expected elements are visible', async ({ page }) => {
+      test('checks expected elements are visible', async ({
+        page,
+        browserName,
+      }) => {
         await interceptCommonApiCalls(page, mailDomainsFixtures);
+
+        await page.goto('/');
+        await keyCloakSignIn(page, browserName, 'mail-member');
 
         await clickOnMailDomainsNavButton(page);
 
@@ -725,8 +758,14 @@ test.describe('Mail domain', () => {
         },
       ];
 
-      test('checks expected elements are visible', async ({ page }) => {
+      test('checks expected elements are visible', async ({
+        page,
+        browserName,
+      }) => {
         await interceptCommonApiCalls(page, mailDomainsFixtures);
+
+        await page.goto('/');
+        await keyCloakSignIn(page, browserName, 'mail-member');
 
         await clickOnMailDomainsNavButton(page);
 
@@ -768,8 +807,14 @@ test.describe('Mail domain', () => {
         },
       ];
 
-      test('checks expected elements are visible', async ({ page }) => {
+      test('checks expected elements are visible', async ({
+        page,
+        browserName,
+      }) => {
         await interceptCommonApiCalls(page, mailDomainsFixtures);
+
+        await page.goto('/');
+        await keyCloakSignIn(page, browserName, 'mail-member');
 
         await clickOnMailDomainsNavButton(page);
 

--- a/src/frontend/apps/e2e/__tests__/app-desk/mail-domains.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/mail-domains.spec.ts
@@ -73,16 +73,14 @@ const mailDomainsFixtures: MailDomain[] = [
 
 test.describe('Mail domains', () => {
   test.describe('checks all the elements are visible', () => {
-    test.beforeEach(async ({ page, browserName }) => {
+    test('checks the sort button', async ({ page, browserName }) => {
       await page.goto('/');
       // The user is a team administrator, so they land on the team page
       // This allows to prevent the redirection to the mail domains page
       // to make the '/api/v1.0/mail-domains/?page=1&ordering=created_at'
       // query at login, which will be cached and not called afterward in tests.
       await keyCloakSignIn(page, browserName, 'team-administrator-mail-member');
-    });
 
-    test('checks the sort button', async ({ page }) => {
       await page
         .locator('menu')
         .first()
@@ -128,7 +126,7 @@ test.describe('Mail domains', () => {
       expect(responseSortDesc.ok()).toBeTruthy();
     });
 
-    test('when no mail domain exists', async ({ page }) => {
+    test('when no mail domain exists', async ({ page, browserName }) => {
       await page.route('**/api/v1.0/mail-domains/?page=*', async (route) => {
         await route.fulfill({
           json: {
@@ -139,6 +137,13 @@ test.describe('Mail domains', () => {
           },
         });
       });
+
+      await page.goto('/');
+      // The user is a team administrator, so they land on the team page
+      // This allows to prevent the redirection to the mail domains page
+      // to make the '/api/v1.0/mail-domains/?page=1&ordering=created_at'
+      // query at login, which will be cached and not called afterward in tests.
+      await keyCloakSignIn(page, browserName, 'team-administrator-mail-member');
 
       await page
         .locator('menu')
@@ -152,7 +157,7 @@ test.describe('Mail domains', () => {
       await expect(page.getByText('No domains exist.')).toBeVisible();
     });
 
-    test('when 4 mail domains exist', async ({ page }) => {
+    test('when 4 mail domains exist', async ({ page, browserName }) => {
       await page.route('**/api/v1.0/mail-domains/?page=*', async (route) => {
         await route.fulfill({
           json: {
@@ -163,6 +168,13 @@ test.describe('Mail domains', () => {
           },
         });
       });
+
+      await page.goto('/');
+      // The user is a team administrator, so they land on the team page
+      // This allows to prevent the redirection to the mail domains page
+      // to make the '/api/v1.0/mail-domains/?page=1&ordering=created_at'
+      // query at login, which will be cached and not called afterward in tests.
+      await keyCloakSignIn(page, browserName, 'team-administrator-mail-member');
 
       await page
         .locator('menu')

--- a/src/frontend/apps/e2e/playwright.config.ts
+++ b/src/frontend/apps/e2e/playwright.config.ts
@@ -9,7 +9,7 @@ const baseURL = `http://localhost:${PORT}`;
  */
 export default defineConfig({
   // Timeout per test
-  timeout: 30 * 1000,
+  timeout: 10 * 1000,
   testDir: './__tests__',
   outputDir: './test-results',
 


### PR DESCRIPTION
## Purpose

Several E2E tests were suffering from a race condition problem. The race condition affected setting up mocked API calls with `page.route` and navigation to the front page of Desk. Specifically, the call to `page.goto('/')` was made _before_ the call to `page.route`, without caring to synchronize the two. This meant that, at random, we could possibly have the API calls made by the front page complete before the mocks were in place, leading to a test failure.

## Proposal

This PR aims to eliminate this source of intermittent CI failures, which are always obnoxious and lead to a waste of time (when we investigate why the build failed), of resources (when we have to rerun jobs) and more importantly a loss of confidence in the test suite.

We systematically have the calls to `page.route` take place (synchronously, with an `await`) before calling `page.goto('/')`. (Unfortunately this means that we cannot make use of `test.beforeEach` in these tests, a price I'm happy to pay as these clauses were only a couple lines each).

(There is one exception to this "rule", `menu-spec.ts`, because the login flow is triggered by a call to the `/users/me` endpoint, which must return a 401 on the first invocation; setting up the mock before the call to `page.goto('/')` interferes with that. We must trigger the login process by loading the home page, then prepare the mock, then proceed with login. Unfortunately I'm not able to find a fix for this that works both locally and in CI, so I'm leaving `menu-spec.ts` unchanged for now.)

In addition, fix some E2E calls that were not making use of `await`, to be more in line with all other E2E tests.

**In addition, lower the default timeout for Playwright tests to 10 seconds, which is plenty.**