### PR TITLE
Automate domain creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- ✨(plugin) add CommuneCreation plugin with domain provisioning #658
 - ✨(frontend) display action required status on domain
 - ✨(domains) store last health check details on MailDomain
 - ✨(domains) add support email field on domain

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ data/static:
 create-env-files: ## Copy the dist env files to env files
 create-env-files: \
 	env.d/development/common \
+	env.d/development/france \
 	env.d/development/crowdin \
 	env.d/development/postgresql \
 	env.d/development/kc_postgresql
@@ -227,6 +228,9 @@ resetdb: ## flush database and create a superuser "admin"
 
 env.d/development/common:
 	cp -n env.d/development/common.dist env.d/development/common
+
+env.d/development/france:
+	cp -n env.d/development/france.dist env.d/development/france
 
 env.d/development/postgresql:
 	cp -n env.d/development/postgresql.dist env.d/development/postgresql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - DJANGO_CONFIGURATION=Development
     env_file:
       - env.d/development/common
+      - env.d/development/france
       - env.d/development/postgresql
     ports:
       - "8071:8000"

--- a/docker/auth/realm.json
+++ b/docker/auth/realm.json
@@ -65,7 +65,7 @@
       "lastName": "Delamairie",
       "enabled": true,
       "attributes": {
-          "siret": "21580304000017"
+          "siret": "21510339100011"
       },
       "credentials": [
         {

--- a/env.d/development/france.dist
+++ b/env.d/development/france.dist
@@ -1,0 +1,1 @@
+ORGANIZATION_PLUGINS=plugins.organizations.NameFromSiretOrganizationPlugin,plugins.organizations.CommuneCreation

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -29,7 +29,10 @@ from timezone_field import TimeZoneField
 from treebeard.mp_tree import MP_Node, MP_NodeManager
 
 from core.enums import WebhookStatusChoices
-from core.plugins.loader import organization_plugins_run_after_create
+from core.plugins.loader import (
+    organization_plugins_run_after_create,
+    organization_plugins_run_after_grant_access,
+)
 from core.utils.webhooks import scim_synchronizer
 from core.validators import get_field_validators_from_setting
 
@@ -295,6 +298,22 @@ class OrganizationManager(models.Manager):
         """
         instance = super().create(**kwargs)
         organization_plugins_run_after_create(instance)
+        return instance
+
+
+class OrganizationAccessManager(models.Manager):
+    """
+    Custom manager for the OrganizationAccess model, to manage complexity/automation.
+    """
+
+    def create(self, **kwargs):
+        """
+        Create an organization access with the given kwargs.
+
+        This method is overridden to call the Organization plugins.
+        """
+        instance = super().create(**kwargs)
+        organization_plugins_run_after_grant_access(instance)
         return instance
 
 
@@ -617,6 +636,8 @@ class OrganizationAccess(BaseModel):
         choices=OrganizationRoleChoices.choices,
         default=OrganizationRoleChoices.ADMIN,
     )
+
+    objects = OrganizationAccessManager()
 
     class Meta:
         db_table = "people_organization_access"
@@ -979,3 +1000,7 @@ class Invitation(BaseModel):
 
         except smtplib.SMTPException as exception:
             logger.error("invitation to %s was not sent: %s", self.email, exception)
+
+
+# It's not clear yet how best to split this file.
+# pylint: disable=C0302

--- a/src/backend/core/plugins/base.py
+++ b/src/backend/core/plugins/base.py
@@ -11,3 +11,9 @@ class BaseOrganizationPlugin:
     def run_after_create(self, organization) -> None:
         """Method called after creating an organization."""
         raise NotImplementedError("Plugins must implement the run_after_create method")
+
+    def run_after_grant_access(self, organization_access) -> None:
+        """Method called after creating an organization."""
+        raise NotImplementedError(
+            "Plugins must implement the run_after_grant_access method"
+        )

--- a/src/backend/core/plugins/loader.py
+++ b/src/backend/core/plugins/loader.py
@@ -30,3 +30,15 @@ def organization_plugins_run_after_create(organization):
     """
     for plugin_instance in get_organization_plugins():
         plugin_instance.run_after_create(organization)
+
+
+def organization_plugins_run_after_grant_access(organization_access):
+    """
+    Run the after grant access method for all organization plugins.
+
+    Each plugin will be called in the order they are listed in the settings.
+    Each plugin is responsible to save changes if needed, this is not optimized
+    but this could be easily improved later if needed.
+    """
+    for plugin_instance in get_organization_plugins():
+        plugin_instance.run_after_grant_access(organization_access)

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -657,8 +657,6 @@ class Development(Base):
 
     OIDC_ORGANIZATION_REGISTRATION_ID_FIELD = "siret"
 
-    ORGANIZATION_PLUGINS = ["plugins.organizations.NameFromSiretOrganizationPlugin"]
-
     def __init__(self):
         """In dev, force installs needed for Swagger API."""
         # pylint: disable=invalid-name
@@ -705,8 +703,6 @@ class Test(Base):
     MAIL_PROVISIONING_API_CREDENTIALS = "bGFfcmVnaWU6cGFzc3dvcmQ="
 
     OIDC_ORGANIZATION_REGISTRATION_ID_FIELD = "siret"
-
-    ORGANIZATION_PLUGINS = ["plugins.organizations.NameFromSiretOrganizationPlugin"]
 
     ORGANIZATION_REGISTRATION_ID_VALIDATORS = [
         {

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -465,6 +465,21 @@ class Base(Configuration):
         environ_name="MAIL_PROVISIONING_API_CREDENTIALS",
         environ_prefix=None,
     )
+    DNS_PROVISIONING_API_URL = values.Value(
+        default="https://api.scaleway.com",
+        environ_name="DNS_PROVISIONING_API_URL",
+        environ_prefix=None,
+    )
+    DNS_PROVISIONING_RESOURCE_ID = values.Value(
+        default=None,
+        environ_name="DNS_PROVISIONING_RESOURCE_ID",
+        environ_prefix=None,
+    )
+    DNS_PROVISIONING_API_CREDENTIALS = values.Value(
+        default=None,
+        environ_name="DNS_PROVISIONING_API_CREDENTIALS",
+        environ_prefix=None,
+    )
 
     # Organizations
     ORGANIZATION_REGISTRATION_ID_VALIDATORS = json.loads(

--- a/src/backend/plugins/organizations.py
+++ b/src/backend/plugins/organizations.py
@@ -1,8 +1,8 @@
 """Organization related plugins."""
 
-from django.conf import settings
-
 import logging
+
+from django.conf import settings
 
 import requests
 from requests.adapters import HTTPAdapter, Retry
@@ -73,9 +73,13 @@ class NameFromSiretOrganizationPlugin(BaseOrganizationPlugin):
         organization.save(update_fields=["name", "updated_at"])
         logger.info("Organization %s name updated to %s", organization, name)
 
+    def run_after_grant_access(self, organization):
+        pass
+
 class ApiCall:
     """Encapsulates a call to an external API"""
 
+    inputs: dict = {}
     method: str = "GET"
     base: str = ""
     url: str = ""
@@ -115,6 +119,19 @@ class CommuneCreation(BaseOrganizationPlugin):
         logger.warning("No organization name found for SIRET %s", siret)
         return None
 
+    def dns_call(self, spec):
+        """Call to add a DNS record"""
+        records = [
+            {"name": item["target"], "type": item["type"], "data": item["value"]}
+            for item in spec.response
+        ]
+        result = ApiCall()
+        result.method = "PATCH"
+        result.base = "https://api.scaleway.com"
+        result.url = f"/domain/v2beta1/dns-zones/{spec.inputs["name"]}.collectivite.fr/records"
+        result.params = {"changes": [{"add": {"records": records}}]}
+        return result
+
     def complete_commune_creation(self, name: str) -> ApiCall:
         """Specify the tasks to be completed after a commune is created."""
         inputs = {"name": name.lower()}
@@ -137,23 +154,28 @@ class CommuneCreation(BaseOrganizationPlugin):
         create_domain.base = settings.MAIL_PROVISIONING_API_URL
         create_domain.url = "/domains"
         create_domain.params = {
-            "name": f"{inputs["name"]}.collectivite.fr",
+            "name": f"{inputs['name']}.collectivite.fr",
             "delivery": "virtual",
-            "features": ["webmail","mailbox"],
-            "context_name": f"{inputs["name"]}.collectivite.fr",
+            "features": ["webmail", "mailbox"],
+            "context_name": f"{inputs['name']}.collectivite.fr",
         }
         create_domain.headers = {
             "Authorization": f"Basic: {settings.MAIL_PROVISIONING_API_CREDENTIALS}"
         }
 
         spec_domain = ApiCall()
+        spec_domain.inputs = inputs
         spec_domain.base = settings.MAIL_PROVISIONING_API_URL
-        spec_domain.url = f"/domains/{inputs["name"]}.collectivite.fr/spec"
+        spec_domain.url = f"/domains/{inputs['name']}.collectivite.fr/spec"
         spec_domain.headers = {
             "Authorization": f"Basic: {settings.MAIL_PROVISIONING_API_CREDENTIALS}"
         }
 
         return [create_zone, create_domain, spec_domain]
+
+    def complete_zone_creation(self, spec_call):
+        """Specify the tasks to be performed to set up the zone."""
+        return self.dns_call(spec_call)
 
     def run_after_create(self, organization):
         """After creating an organization, update the organization name."""
@@ -183,3 +205,6 @@ class CommuneCreation(BaseOrganizationPlugin):
         organization.name = name
         organization.save(update_fields=["name", "updated_at"])
         logger.info("Organization %s name updated to %s", organization, name)
+
+    def run_after_grant_access(self, organization):
+        pass

--- a/src/backend/plugins/organizations.py
+++ b/src/backend/plugins/organizations.py
@@ -137,10 +137,10 @@ class CommuneCreation(BaseOrganizationPlugin):
         create_domain.base = settings.MAIL_PROVISIONING_API_URL
         create_domain.url = "/domains"
         create_domain.params = {
-            "name": inputs["name"],
+            "name": f"{inputs["name"]}.collectivite.fr",
             "delivery": "virtual",
             "features": ["webmail","mailbox"],
-            "context_name": inputs["name"],
+            "context_name": f"{inputs["name"]}.collectivite.fr",
         }
         create_domain.headers = {
             "Authorization": f"Basic: {settings.MAIL_PROVISIONING_API_CREDENTIALS}"

--- a/src/backend/plugins/organizations.py
+++ b/src/backend/plugins/organizations.py
@@ -250,7 +250,7 @@ class CommuneCreation(BaseOrganizationPlugin):
         zone_name = orga.name.lower() + ".collectivite.fr"
 
         try:
-            domain = MailDomain.objects.get(domain=zone_name)
+            domain = MailDomain.objects.get(name=zone_name)
         except MailDomain.DoesNotExist:
             domain = None
 

--- a/src/backend/plugins/organizations.py
+++ b/src/backend/plugins/organizations.py
@@ -1,5 +1,7 @@
 """Organization related plugins."""
 
+from django.conf import settings
+
 import logging
 
 import requests
@@ -27,14 +29,8 @@ class NameFromSiretOrganizationPlugin(BaseOrganizationPlugin):
     def get_organization_name_from_results(data, siret):
         """Return the organization name from the results of a SIRET search."""
         for result in data["results"]:
-            is_commune = (
-                result.get("nature_juridique") == "7210"
-            )  # INSEE code for commune
             for organization in result["matching_etablissements"]:
                 if organization.get("siret") == siret:
-                    if is_commune:
-                        return organization["libelle_commune"].title()
-
                     store_signs = organization.get("liste_enseignes") or []
                     if store_signs:
                         return store_signs[0].title()
@@ -52,6 +48,110 @@ class NameFromSiretOrganizationPlugin(BaseOrganizationPlugin):
 
         if organization.name not in organization.registration_id_list:
             # The name has probably already been customized
+            return
+
+        # In the nominal case, there is only one registration ID because
+        # the organization as been created from it.
+        try:
+            # Retry logic as the API may be rate limited
+            s = requests.Session()
+            retries = Retry(total=5, backoff_factor=0.1, status_forcelist=[429])
+            s.mount("https://", HTTPAdapter(max_retries=retries))
+
+            siret = organization.registration_id_list[0]
+            response = s.get(self._api_url.format(siret=siret), timeout=10)
+            response.raise_for_status()
+            data = response.json()
+            name = self.get_organization_name_from_results(data, siret)
+            if not name:
+                return
+        except requests.RequestException as exc:
+            logger.exception("%s: Unable to fetch organization name from SIRET", exc)
+            return
+
+        organization.name = name
+        organization.save(update_fields=["name", "updated_at"])
+        logger.info("Organization %s name updated to %s", organization, name)
+
+class ApiCall:
+    """Encapsulates a call to an external API"""
+
+    method: str = "GET"
+    base: str = ""
+    url: str = ""
+    params: dict = {}
+    headers: dict = {}
+    response = None
+
+    def execute(self):
+        """Call the specified API endpoint with supplied parameters and record response"""
+        if self.method == "POST":
+            self.response = requests.request(
+                method=self.method,
+                url=f"{self.base}/{self.url}",
+                json=self.params,
+                headers=self.headers,
+                timeout=5,
+            )
+
+
+class CommuneCreation(BaseOrganizationPlugin):
+    """
+    This plugin handles setup tasks for French communes.
+    """
+
+    _api_url = "https://recherche-entreprises.api.gouv.fr/search?q={siret}"
+
+    def get_organization_name_from_results(self, data, siret):
+        """Return the organization name from the results of a SIRET search."""
+        for result in data["results"]:
+            nature = "nature_juridique"
+            commune = nature in result and result[nature] == "7210"
+            for organization in result["matching_etablissements"]:
+                if organization.get("siret") == siret:
+                    if commune:
+                        return organization["libelle_commune"].title()
+
+        logger.warning("No organization name found for SIRET %s", siret)
+        return None
+
+    def complete_commune_creation(self, name: str) -> ApiCall:
+        """Specify the tasks to be completed after a commune is created."""
+        inputs = {"name": name.lower()}
+
+        create_zone = ApiCall()
+        create_zone.method = "POST"
+        create_zone.base = "https://api.scaleway.com"
+        create_zone.url = "/domain/v2beta1/dns-zones"
+        create_zone.params = {
+            "project_id": settings.DNS_PROVISIONING_RESOURCE_ID,
+            "domain": "collectivite.fr",
+            "subdomain": inputs["name"],
+        }
+        create_zone.headers = {
+            "X-Auth-Token": settings.DNS_PROVISIONING_API_CREDENTIALS
+        }
+
+        create_domain = ApiCall()
+        create_domain.method = "POST"
+        create_domain.base = settings.MAIL_PROVISIONING_API_URL
+        create_domain.url = "/domains"
+        create_domain.params = {
+            "name": inputs["name"],
+            "delivery": "virtual",
+            "features": ["webmail"],
+            "context_name": inputs["name"],
+        }
+        create_domain.headers = {
+            "Authorization": f"Basic: {settings.MAIL_PROVISIONING_API_CREDENTIALS}"
+        }
+
+        return [create_zone, create_domain]
+
+    def run_after_create(self, organization):
+        """After creating an organization, update the organization name."""
+        if not organization.registration_id_list:
+            # No registration ID to convert...
             return
 
         # In the nominal case, there is only one registration ID because

--- a/src/backend/plugins/organizations.py
+++ b/src/backend/plugins/organizations.py
@@ -139,14 +139,21 @@ class CommuneCreation(BaseOrganizationPlugin):
         create_domain.params = {
             "name": inputs["name"],
             "delivery": "virtual",
-            "features": ["webmail"],
+            "features": ["webmail","mailbox"],
             "context_name": inputs["name"],
         }
         create_domain.headers = {
             "Authorization": f"Basic: {settings.MAIL_PROVISIONING_API_CREDENTIALS}"
         }
 
-        return [create_zone, create_domain]
+        spec_domain = ApiCall()
+        spec_domain.base = settings.MAIL_PROVISIONING_API_URL
+        spec_domain.url = f"/domains/{inputs["name"]}.collectivite.fr/spec"
+        spec_domain.headers = {
+            "Authorization": f"Basic: {settings.MAIL_PROVISIONING_API_CREDENTIALS}"
+        }
+
+        return [create_zone, create_domain, spec_domain]
 
     def run_after_create(self, organization):
         """After creating an organization, update the organization name."""

--- a/src/backend/plugins/tests/organizations/test_commune_creation.py
+++ b/src/backend/plugins/tests/organizations/test_commune_creation.py
@@ -88,10 +88,10 @@ def test_tasks_on_commune_creation_include_dimail_domain_creation():
     assert tasks[1].url == "/domains"
     assert tasks[1].method == "POST"
     assert tasks[1].params == {
-        "name": "merlaut",
+        "name": "merlaut.collectivite.fr",
         "delivery": "virtual",
         "features": ["webmail", "mailbox"],
-        "context_name": "merlaut",
+        "context_name": "merlaut.collectivite.fr",
     }
     assert (
         tasks[1].headers["Authorization"]

--- a/src/backend/plugins/tests/organizations/test_commune_creation.py
+++ b/src/backend/plugins/tests/organizations/test_commune_creation.py
@@ -90,10 +90,25 @@ def test_tasks_on_commune_creation_include_dimail_domain_creation():
     assert tasks[1].params == {
         "name": "merlaut",
         "delivery": "virtual",
-        "features": ["webmail"],
+        "features": ["webmail", "mailbox"],
         "context_name": "merlaut",
     }
     assert (
         tasks[1].headers["Authorization"]
+        == f"Basic: {settings.MAIL_PROVISIONING_API_CREDENTIALS}"
+    )
+
+def test_tasks_on_commune_creation_include_fetching_spec():
+    """Test the third task in commune creation: asking Dimail for the spec"""
+    plugin = CommuneCreation()
+    name = "Loc-Eguiner"
+
+    tasks = plugin.complete_commune_creation(name)
+
+    assert tasks[2].base == settings.MAIL_PROVISIONING_API_URL
+    assert tasks[2].url == "/domains/loc-eguiner.collectivite.fr/spec"
+    assert tasks[2].method == "GET"
+    assert (
+        tasks[2].headers["Authorization"]
         == f"Basic: {settings.MAIL_PROVISIONING_API_CREDENTIALS}"
     )

--- a/src/backend/plugins/tests/organizations/test_commune_creation.py
+++ b/src/backend/plugins/tests/organizations/test_commune_creation.py
@@ -169,3 +169,23 @@ def test_tasks_on_commune_creation_include_dns_records():
     assert (
         zone_call.headers["X-Auth-Token"] == settings.DNS_PROVISIONING_API_CREDENTIALS
     )
+
+
+def test_normalize_name():
+    """Test name normalization"""
+    plugin = CommuneCreation()
+    assert plugin.normalize_name("Asnières-sur-Saône") == "asnieres-sur-saone"
+    assert plugin.normalize_name("Bâgé-le-Châtel") == "bage-le-chatel"
+    assert plugin.normalize_name("Courçais") == "courcais"
+    assert plugin.normalize_name("Moÿ-de-l'Aisne") == "moy-de-l-aisne"
+    assert plugin.normalize_name("Salouël") == "salouel"
+    assert (
+        plugin.normalize_name("Bors (Canton de Tude-et-Lavalette)")
+        == "bors-canton-de-tude-et-lavalette"
+    )
+
+
+def test_zone_name():
+    """Test transforming a commune name to a sub-zone of collectivite.fr"""
+    plugin = CommuneCreation()
+    assert plugin.zone_name("Bâgé-le-Châtel") == "bage-le-chatel.collectivite.fr"

--- a/src/backend/plugins/tests/organizations/test_commune_creation.py
+++ b/src/backend/plugins/tests/organizations/test_commune_creation.py
@@ -1,0 +1,99 @@
+"""Tests for the CommuneCreation plugin."""
+
+from django.conf import settings
+
+import pytest
+import responses
+
+from plugins.organizations import ApiCall, CommuneCreation
+
+pytestmark = pytest.mark.django_db
+
+def test_extract_name_from_org_data_when_commune():
+    """Test the name is extracted correctly for a French commune."""
+    data = {
+        "results": [
+            {
+                "nom_complet": "COMMUNE DE VARZY",
+                "nom_raison_sociale": "COMMUNE DE VARZY",
+                "siege": {
+                    "libelle_commune": "VARZY",
+                    "liste_enseignes": ["MAIRIE"],
+                    "siret": "21580304000017",
+                },
+                "nature_juridique": "7210",
+                "matching_etablissements": [
+                    {
+                        "siret": "21580304000017",
+                        "libelle_commune": "VARZY",
+                        "liste_enseignes": ["MAIRIE"],
+                    }
+                ],
+            }
+        ]
+    }
+
+    plugin = CommuneCreation()
+    name = plugin.get_organization_name_from_results(data, "21580304000017")
+    assert name == "Varzy"
+
+
+def test_api_call_execution():
+    """Test that calling execute() faithfully executes the API call"""
+    task = ApiCall()
+    task.method = "POST"
+    task.base = "https://some_host"
+    task.url = "some_url"
+    task.params = {"some_key": "some_value"}
+    task.headers = {"Some-Header": "Some-Header-Value"}
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            rsps.POST,
+            url="https://some_host/some_url",
+            body='{"some_key": "some_value"}',
+            content_type="application/json",
+            headers={"Some-Header": "Some-Header-Value"},
+        )
+
+        task.execute()
+
+
+def test_tasks_on_commune_creation_include_zone_creation():
+    """Test the first task in commune creation: creating the DNS sub-zone"""
+    plugin = CommuneCreation()
+    name = "Varzy"
+
+    tasks = plugin.complete_commune_creation(name)
+
+    assert tasks[0].base == "https://api.scaleway.com"
+    assert tasks[0].url == "/domain/v2beta1/dns-zones"
+    assert tasks[0].method == "POST"
+    assert tasks[0].params == {
+        "project_id": settings.DNS_PROVISIONING_RESOURCE_ID,
+        "domain": "collectivite.fr",
+        "subdomain": "varzy",
+    }
+    assert tasks[0].headers["X-Auth-Token"] == settings.DNS_PROVISIONING_API_CREDENTIALS
+
+
+def test_tasks_on_commune_creation_include_dimail_domain_creation():
+    """Test the second task in commune creation: creating the domain in Dimail"""
+    plugin = CommuneCreation()
+    name = "Merlaut"
+
+    tasks = plugin.complete_commune_creation(name)
+
+    assert tasks[1].base == settings.MAIL_PROVISIONING_API_URL
+    assert tasks[1].url == "/domains"
+    assert tasks[1].method == "POST"
+    assert tasks[1].params == {
+        "name": "merlaut",
+        "delivery": "virtual",
+        "features": ["webmail"],
+        "context_name": "merlaut",
+    }
+    assert (
+        tasks[1].headers["Authorization"]
+        == f"Basic: {settings.MAIL_PROVISIONING_API_CREDENTIALS}"
+    )

--- a/src/backend/plugins/tests/organizations/test_name_from_siret_organization_plugin.py
+++ b/src/backend/plugins/tests/organizations/test_name_from_siret_organization_plugin.py
@@ -139,37 +139,6 @@ def test_organization_plugins_run_after_create_name_already_set(
     assert organization.name == "Magic WOW"
 
 
-def test_extract_name_from_org_data_when_commune(
-    organization_plugins_settings,
-):
-    """Test the name is extracted correctly for a French commune."""
-    data = {
-        "results": [
-            {
-                "nom_complet": "COMMUNE DE VARZY",
-                "nom_raison_sociale": "COMMUNE DE VARZY",
-                "siege": {
-                    "libelle_commune": "VARZY",
-                    "liste_enseignes": ["MAIRIE"],
-                    "siret": "21580304000017",
-                },
-                "nature_juridique": "7210",
-                "matching_etablissements": [
-                    {
-                        "siret": "21580304000017",
-                        "libelle_commune": "VARZY",
-                        "liste_enseignes": ["MAIRIE"],
-                    }
-                ],
-            }
-        ]
-    }
-
-    plugin = NameFromSiretOrganizationPlugin()
-    name = plugin.get_organization_name_from_results(data, "21580304000017")
-    assert name == "Varzy"
-
-
 @responses.activate
 def test_organization_plugins_run_after_create_no_list_enseignes(
     organization_plugins_settings,

--- a/src/backend/plugins/tests/organizations/test_name_from_siret_organization_plugin.py
+++ b/src/backend/plugins/tests/organizations/test_name_from_siret_organization_plugin.py
@@ -6,8 +6,6 @@ import responses
 from core.models import Organization
 from core.plugins.loader import get_organization_plugins
 
-from plugins.organizations import NameFromSiretOrganizationPlugin
-
 pytestmark = pytest.mark.django_db
 
 

--- a/src/frontend/apps/e2e/__tests__/app-desk/domain-provisioning.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/domain-provisioning.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test';
+
+import { keyCloakSignIn } from './common';
+
+test.beforeEach(async ({ page, browserName }) => {
+  await page.goto('/');
+  await keyCloakSignIn(page, browserName, 'marie');
+});
+
+test.describe('When a commune, domain is created on first login via ProConnect', () => {
+  test('it checks the domain has been created', async ({ page }) => {
+    const header = page.locator('header').first();
+    await expect(header.getByAltText('Marianne Logo')).toBeVisible();
+
+    await page
+      .locator('menu')
+      .first()
+      .getByLabel(`Mail Domains button`)
+      .click();
+    await expect(page).toHaveURL(/mail-domains\//);
+    await expect(
+      page.getByLabel('Mail domains panel', { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText('merlaut.collectivite.fr')).toHaveCount(1);
+    await expect(page.getByText('No domains exist.')).toHaveCount(0);
+  });
+});

--- a/src/frontend/apps/e2e/__tests__/app-desk/siret.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/siret.spec.ts
@@ -14,7 +14,7 @@ test.describe('OIDC interop with SIRET', () => {
     );
     expect(response.ok()).toBeTruthy();
     expect(await response.json()).toMatchObject({
-      organization: { registration_id_list: ['21580304000017'] },
+      organization: { registration_id_list: ['21510339100011'] },
     });
   });
 });
@@ -28,6 +28,6 @@ test.describe('When a commune, display commune name below user name', () => {
       name: 'Marie Delamairie',
     });
 
-    await expect(logout.getByText('Varzy')).toBeVisible();
+    await expect(logout.getByText('Merlaut')).toBeVisible();
   });
 });

--- a/src/helm/env.d/dev-keycloak/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/dev-keycloak/values.desk.yaml.gotmpl
@@ -32,7 +32,6 @@ backend:
     OIDC_RP_SCOPES: "openid email siret"
     OIDC_REDIRECT_ALLOWED_HOSTS: https://desk.127.0.0.1.nip.io
     OIDC_AUTH_REQUEST_EXTRA_PARAMS: "{'acr_values': 'eidas1'}"
-    ORGANIZATION_PLUGINS: "plugins.organizations.NameFromSiretOrganizationPlugin"
     ORGANIZATION_REGISTRATION_ID_VALIDATORS: '[{"NAME": "django.core.validators.RegexValidator", "OPTIONS": {"regex": "^[0-9]{14}$"}}]'
     LOGIN_REDIRECT_URL: https://desk.127.0.0.1.nip.io
     LOGIN_REDIRECT_URL_FAILURE: https://desk.127.0.0.1.nip.io

--- a/src/helm/env.d/dev/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.desk.yaml.gotmpl
@@ -51,7 +51,6 @@ backend:
     USER_OIDC_FIELDS_TO_NAME: "given_name,usual_name"
     OIDC_REDIRECT_ALLOWED_HOSTS: https://desk.127.0.0.1.nip.io
     OIDC_AUTH_REQUEST_EXTRA_PARAMS: "{'acr_values': 'eidas1'}"
-    ORGANIZATION_PLUGINS: "plugins.organizations.NameFromSiretOrganizationPlugin"
     ORGANIZATION_REGISTRATION_ID_VALIDATORS: '[{"NAME": "django.core.validators.RegexValidator", "OPTIONS": {"regex": "^[0-9]{14}$"}}]'
     LOGIN_REDIRECT_URL: https://desk.127.0.0.1.nip.io
     LOGIN_REDIRECT_URL_FAILURE: https://desk.127.0.0.1.nip.io


### PR DESCRIPTION
## Purpose

Completing #583, ensure users from communes can do something meaningful upon onboarding: create a default domain for them, so that they can create mailboxes

## Proposal

- Segregate France-specific dev settings so that they are easy to disable for other countries
- Call Scaleway API upon organization creation to provision subzone and email-related DNS entries
- Extend plugin mechanism to grant admin access to the newly created domain in Dimail
- Introduce ApiCall object, to avoid mocking and anticipating task queuing
