### PR TITLE
🧑‍💻(api) activate swagger

### DIFF
--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -76,7 +76,7 @@ class Base(Configuration):
     """
 
     DEBUG = False
-    USE_SWAGGER = False
+    USE_SWAGGER = True
 
     API_VERSION = "v1.0"
 


### PR DESCRIPTION
## Purpose

I want to activate swagger to document our API.

Sam said:
Je pense qu'il ne faut pas le mettre en prod parce qu'il génère des fuites mémoire. La dernière fois que j'ai regardé en tous cas...
donc c'est volontairement désactivé ailleurs qu'en local
je crois me souvenir qu'il y a un moyen de le générer comme un site statique et ce serait ça la meilleure pratique parce que même sans la fuite mémoire il est très gourmand en RAM/CPU (il introspecte beaucoup de choses).

L'issue liée : https://github.com/tfranzel/drf-spectacular/issues/597

J'enquête.

## Hints

- Générer en statique
- Discuter avec @lunika 
- https://github.com/tfranzel/drf-spectacular?tab=readme-ov-file#take-it-for-a-spin ?

## Proposal

Description...

- [] item 1...
- [] item 2...
