### PR TITLE
🚑️(teams) do not display add button when disallowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🚑️(teams) do not display add button when disallowed #676
 - 🚑️(plugins) fix name from SIRET specific case #674
 - 🐛(api) restrict mailbox sync to enabled domains
 

--- a/src/backend/core/api/client/viewsets.py
+++ b/src/backend/core/api/client/viewsets.py
@@ -303,7 +303,7 @@ class TeamViewSet(
 ):
     """Team ViewSet"""
 
-    permission_classes = [permissions.AccessPermission]
+    permission_classes = [permissions.TeamPermission, permissions.AccessPermission]
     serializer_class = serializers.TeamSerializer
     filter_backends = [filters.OrderingFilter]
     ordering_fields = ["created_at", "name", "path"]

--- a/src/backend/core/api/permissions.py
+++ b/src/backend/core/api/permissions.py
@@ -53,3 +53,18 @@ class AccessPermission(IsAuthenticated):
         """Check permission for a given object."""
         abilities = obj.get_abilities(request.user)
         return abilities.get(request.method.lower(), False)
+
+
+class TeamPermission(IsAuthenticated):
+    """Permission class for team objects viewset."""
+
+    def has_permission(self, request, view):
+        """Check permission only when the user tries to create a new team."""
+        if not super().has_permission(request, view):
+            return False
+
+        if request.method != "POST":
+            return True
+
+        abilities = request.user.get_abilities()
+        return abilities["teams"]["can_create"]

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -573,7 +573,7 @@ class User(AbstractBaseUser, BaseModel, auth_models.PermissionsMixin):
             .get()
         )
 
-        teams_can_view = user_info.teams_can_view
+        teams_can_view = user_info.teams_can_view or settings.FEATURES["TEAMS_DISPLAY"]
         mailboxes_can_view = user_info.mailboxes_can_view
 
         return {
@@ -585,7 +585,7 @@ class User(AbstractBaseUser, BaseModel, auth_models.PermissionsMixin):
                 ),
             },
             "teams": {
-                "can_view": teams_can_view and settings.FEATURES["TEAMS_DISPLAY"],
+                "can_view": teams_can_view,
                 "can_create": teams_can_view and settings.FEATURES["TEAMS_CREATE"],
             },
             "mailboxes": {

--- a/src/backend/core/tests/users/test_api_users_retrieve.py
+++ b/src/backend/core/tests/users/test_api_users_retrieve.py
@@ -56,7 +56,7 @@ def test_api_users_retrieve_me_authenticated():
         "abilities": {
             "contacts": {"can_create": True, "can_view": True},
             "mailboxes": {"can_create": False, "can_view": False},
-            "teams": {"can_create": False, "can_view": False},
+            "teams": {"can_create": True, "can_view": True},
         },
         "organization": {
             "id": str(user.organization.pk),
@@ -66,11 +66,18 @@ def test_api_users_retrieve_me_authenticated():
     }
 
 
-def test_api_users_retrieve_me_authenticated_abilities():
+def test_api_users_retrieve_me_authenticated_abilities(settings):
     """
     Authenticated users should be able to retrieve their own user via the "/users/me" path
     with the proper abilities.
     """
+    settings.FEATURES = {
+        "TEAMS_DISPLAY": False,
+        "TEAMS_CREATE": True,
+        "CONTACTS_DISPLAY": True,
+        "CONTACTS_CREATE": True,
+        "MAILBOXES_CREATE": True,
+    }
     user = factories.UserFactory()
 
     client = APIClient()

--- a/src/frontend/apps/desk/src/features/teams/teams-panel/__tests__/PanelTeams.test.tsx
+++ b/src/frontend/apps/desk/src/features/teams/teams-panel/__tests__/PanelTeams.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 
+import { useAuthStore } from '@/core/auth';
 import { AppWrapper } from '@/tests/utils';
 
 import { Panel } from '../components/Panel';
@@ -23,6 +24,19 @@ describe('PanelTeams', () => {
   });
 
   it('renders with no team to display', async () => {
+    useAuthStore.setState({
+      userData: {
+        id: '1',
+        email: 'test@example.com',
+        name: 'Test User',
+        abilities: {
+          teams: { can_view: true, can_create: true },
+          mailboxes: { can_view: true },
+          contacts: { can_view: true },
+        },
+      },
+    });
+
     fetchMock.mock(`end:/teams/?ordering=-created_at`, []);
 
     render(<TeamList />, { wrapper: AppWrapper });

--- a/src/frontend/apps/desk/src/features/teams/teams-panel/components/PanelActions.tsx
+++ b/src/frontend/apps/desk/src/features/teams/teams-panel/components/PanelActions.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import IconAdd from '@/assets/icons/icon-add.svg';
 import IconSort from '@/assets/icons/icon-sort.svg';
 import { Box, BoxButton, StyledLink } from '@/components';
+import { useAuthStore } from '@/core/auth';
 import { useCunninghamTheme } from '@/cunningham';
 import { TeamsOrdering } from '@/features/teams/team-management/api';
 
@@ -13,6 +14,9 @@ export const PanelActions = () => {
   const { t } = useTranslation();
   const { changeOrdering, ordering } = useTeamStore();
   const { colorsTokens } = useCunninghamTheme();
+  const { userData } = useAuthStore();
+
+  const can_create = userData?.abilities?.teams.can_create ?? false;
 
   const isSortAsc = ordering === TeamsOrdering.BY_CREATED_ON;
 
@@ -43,17 +47,19 @@ export const PanelActions = () => {
       >
         <IconSort width={30} height={30} aria-hidden="true" />
       </BoxButton>
-      <StyledLink href="/teams/create">
-        <BoxButton
-          as="span"
-          $margin={{ all: 'auto' }}
-          aria-label={t('Add a team')}
-          $color={colorsTokens()['primary-600']}
-          tabIndex={-1}
-        >
-          <IconAdd width={27} height={27} aria-hidden="true" />
-        </BoxButton>
-      </StyledLink>
+      {can_create && (
+        <StyledLink href="/teams/create">
+          <BoxButton
+            as="span"
+            $margin={{ all: 'auto' }}
+            aria-label={t('Add a team')}
+            $color={colorsTokens()['primary-600']}
+            tabIndex={-1}
+          >
+            <IconAdd width={27} height={27} aria-hidden="true" />
+          </BoxButton>
+        </StyledLink>
+      )}
     </Box>
   );
 };

--- a/src/frontend/apps/desk/src/features/teams/teams-panel/components/TeamList.tsx
+++ b/src/frontend/apps/desk/src/features/teams/teams-panel/components/TeamList.tsx
@@ -3,6 +3,7 @@ import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Box, Text } from '@/components';
+import { useAuthStore } from '@/core/auth';
 import { Team, useTeams } from '@/features/teams/team-management';
 
 import { useTeamStore } from '../store';
@@ -17,6 +18,9 @@ interface PanelTeamsStateProps {
 
 const TeamListState = ({ isLoading, isError, teams }: PanelTeamsStateProps) => {
   const { t } = useTranslation();
+  const { userData } = useAuthStore();
+
+  const can_create = userData?.abilities?.teams.can_create ?? false;
 
   if (isError) {
     return (
@@ -42,11 +46,13 @@ const TeamListState = ({ isLoading, isError, teams }: PanelTeamsStateProps) => {
         <Text as="p" $margin={{ vertical: 'none' }}>
           {t('0 group to display.')}
         </Text>
-        <Text as="p">
-          {t(
-            'Create your first team by clicking on the "Create a new team" button.',
-          )}
-        </Text>
+        {can_create && (
+          <Text as="p">
+            {t(
+              'Create your first team by clicking on the "Create a new team" button.',
+            )}
+          </Text>
+        )}
       </Box>
     );
   }

--- a/src/frontend/apps/e2e/__tests__/app-desk/config.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/config.spec.ts
@@ -39,9 +39,18 @@ test.describe('Config', () => {
     await page.goto('/');
     await keyCloakSignIn(page, browserName, 'mail-member');
 
-    await expect(page.locator('menu')).toBeHidden();
+    await page
+      .locator('menu')
+      .first()
+      .getByLabel(`Mail Domains button`)
+      .click();
+    await expect(page).toHaveURL(/mail-domains\//);
 
-    await expect(page.getByText('Mail Domains')).toBeVisible();
+    await expect(
+      page
+        .getByLabel('Mail domains panel', { exact: true })
+        .getByText('Mail Domains'),
+    ).toBeVisible();
   });
 
   test('it checks that the user abilities display teams', async ({


### PR DESCRIPTION
## Purpose

The frontend should not display "add team" actions when the user has not the ability.
When we don't allow the user to see the team creation button, we also want to disable the corresponding API.

## Proposal

- [x] hide team creation button according to user abilities
- [x] check user abilities on team creation endpoint
