### PR TITLE
🐛(mailbox) fix status of some mailboxes in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(mailbox) fix status of some mailboxes in production
 - 🚑️(teams) do not display add button when disallowed #676
 - 🚑️(plugins) fix name from SIRET specific case #674
 - 🐛(api) restrict mailbox sync to enabled domains

--- a/src/backend/mailbox_manager/migrations/0018_fix_mailboxes_status.py
+++ b/src/backend/mailbox_manager/migrations/0018_fix_mailboxes_status.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+from mailbox_manager import enums
+
+
+def change_some_mailboxes_status_to_enabled(apps, schema_editor):
+    Mailbox = apps.get_model('mailbox_manager', 'Mailbox')
+    Mailbox.objects.filter(
+        status=enums.MailboxStatusChoices.PENDING,
+        domain__name__in=["mail.numerique.gouv.fr", "data.gouv.fr"]
+        ).update(status=enums.MailboxStatusChoices.ENABLED)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mailbox_manager', '0017_alter_maildomain_status'),
+    ]
+
+    operations = [
+        migrations.RunPython(change_some_mailboxes_status_to_enabled, reverse_code=migrations.RunPython.noop),
+
+    ]


### PR DESCRIPTION
All mailboxes imported from "mail.numerique.gouv.fr" and "data.gouv.fr" must be in an enabled state and not pending.
Use a data migration to fix it.
