### PR TITLE
🔧(helm) add pdbs to deployments

### DIFF
--- a/src/helm/desk/Chart.yaml
+++ b/src/helm/desk/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 type: application
 name: desk
-version: 0.0.1
+version: 0.0.2

--- a/src/helm/desk/README.md
+++ b/src/helm/desk/README.md
@@ -37,6 +37,7 @@
 
 | Name                                                  | Description                                                                        | Value                                                                            |
 | ----------------------------------------------------- | ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `backend.pdb.enabled`                                 | Enable pdb on backend                                                              | `true`                                                                           |
 | `backend.dpAnnotations`                               | Annotations to add to the backend Deployment                                       | `{}`                                                                             |
 | `backend.command`                                     | Override the backend container command                                             | `[]`                                                                             |
 | `backend.args`                                        | Override the backend container args                                                | `[]`                                                                             |
@@ -86,6 +87,7 @@
 
 | Name                                                   | Description                                                                         | Value                     |
 | ------------------------------------------------------ | ----------------------------------------------------------------------------------- | ------------------------- |
+| `frontend.pdb.enabled`                                 | Enable pdb on backend                                                               | `true`                    |
 | `frontend.image.repository`                            | Repository to use to pull desk's frontend container image                           | `lasuite/people-frontend` |
 | `frontend.image.tag`                                   | desk's frontend container tag                                                       | `latest`                  |
 | `frontend.image.pullPolicy`                            | frontend container image pull policy                                                | `IfNotPresent`            |

--- a/src/helm/desk/templates/backend_deployment.yaml
+++ b/src/helm/desk/templates/backend_deployment.yaml
@@ -138,3 +138,16 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
+---
+{{ if .Values.backend.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "desk.common.selectorLabels" (list . $component) | nindent 6 }}
+{{ end }}

--- a/src/helm/desk/templates/frontend_deployment.yaml
+++ b/src/helm/desk/templates/frontend_deployment.yaml
@@ -138,3 +138,16 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
+---
+{{ if .Values.frontend.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "desk.common.selectorLabels" (list . $component) | nindent 6 }}
+{{ end }}

--- a/src/helm/desk/values.yaml
+++ b/src/helm/desk/values.yaml
@@ -72,6 +72,10 @@ ingressAdmin:
 ## @section backend
 
 backend:
+  ## @param backend.pdb.enabled Enable pdb on backend
+  pdb:
+    enabled: true
+
   ## @param backend.dpAnnotations Annotations to add to the backend Deployment
   dpAnnotations: {}
 
@@ -179,6 +183,10 @@ backend:
 
 ## @section frontend
 frontend:
+  ## @param frontend.pdb.enabled Enable pdb on backend
+  pdb:
+    enabled: true
+
   ## @param frontend.image.repository Repository to use to pull desk's frontend container image
   ## @param frontend.image.tag desk's frontend container tag
   ## @param frontend.image.pullPolicy frontend container image pull policy


### PR DESCRIPTION
In order to avoid a service interruption during a Kubernetes (k8s)upgrade, we add a Pod Disruption Budget (PDB) to deployments.