### PR TITLE
🐛(plugin) fix support email

### DIFF
--- a/src/backend/plugins/organizations.py
+++ b/src/backend/plugins/organizations.py
@@ -249,7 +249,7 @@ class CommuneCreation(BaseOrganizationPlugin):
         logger.info("Organization %s name updated to %s", organization, name)
 
         zone_name = self.zone_name(name)
-        support = f"support@{zone_name}"
+        support = "support-regie@numerique.gouv.fr"
         MailDomain.objects.get_or_create(name=zone_name, support_email=support)
 
         # Compute and execute the rest of the process


### PR DESCRIPTION
Use a real email to contact support in case
of actions required on the domain in collectivite.fr

