### PR TITLE
:loud_sound:(prod) move logging config up to Base configuration class

### DIFF
--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -323,6 +323,42 @@ class Base(Configuration):
     SESSION_CACHE_ALIAS = "default"
     SESSION_COOKIE_AGE = 60 * 60 * 12  # 12 hours to match Agent Connect
 
+    # Python loggers configuration (and env var overrides)
+    LOGGING = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "simple": {
+                "format": "{asctime} {name} {levelname} {message}",
+                "style": "{",
+            },
+        },
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "formatter": "simple",
+            },
+        },
+        # Override root logger to send it to console
+        "root": {
+            "handlers": ["console"],
+            "level": values.Value(
+                "INFO", environ_name="LOGGING_LEVEL_LOGGERS_ROOT", environ_prefix=None
+            ),
+        },
+        "loggers": {
+            "core": {
+                "handlers": ["console"],
+                "level": values.Value(
+                    "INFO",
+                    environ_name="LOGGING_LEVEL_LOGGERS_APP",
+                    environ_prefix=None,
+                ),
+                "propagate": False,
+            },
+        },
+    }
+
     # OIDC - Authorization Code Flow
     OIDC_CREATE_USER = values.BooleanValue(
         default=True,
@@ -616,41 +652,6 @@ class Development(Base):
     SESSION_COOKIE_NAME = "people_sessionid"
 
     USE_SWAGGER = True
-
-    LOGGING = {
-        "version": 1,
-        "disable_existing_loggers": False,
-        "formatters": {
-            "simple": {
-                "format": "{asctime} {name} {levelname} {message}",
-                "style": "{",
-            },
-        },
-        "handlers": {
-            "console": {
-                "class": "logging.StreamHandler",
-                "formatter": "simple",
-            },
-        },
-        # Override root logger to send it to console
-        "root": {
-            "handlers": ["console"],
-            "level": values.Value(
-                "INFO", environ_name="LOGGING_LEVEL_LOGGERS_ROOT", environ_prefix=None
-            ),
-        },
-        "loggers": {
-            "core": {
-                "handlers": ["console"],
-                "level": values.Value(
-                    "INFO",
-                    environ_name="LOGGING_LEVEL_LOGGERS_APP",
-                    environ_prefix=None,
-                ),
-                "propagate": False,
-            },
-        },
-    }
 
     # this is a dev credentials for mail provisioning API
     MAIL_PROVISIONING_API_CREDENTIALS = "bGFfcmVnaWU6cGFzc3dvcmQ="


### PR DESCRIPTION
## Purpose

Make it possible to set logging configuration on a per-deployment basis in production, so we can actually see our application logs in our production environment.

## Proposal

Currently, LOGGING is defined only on the Development class. This means that the Staging, PreProduction and Production classes, which are used in our prod environments, do not define any logger options. As a result, our production environments use the default Python logging configuration: a log level of WARNING, and no timestamping of logs, among other things.

This PR moves up the LOGGING definition, to the Base class, this way Production and subclasses will inherit it. This will make INFO the default log level for the root and app loggers. This definition includes an environment variable mapping, so we can still configure a different log level for those if necessary.