### PR TITLE
💄(frontend) change support email example

### DIFF
--- a/src/frontend/apps/desk/src/features/mail-domains/domains/components/ModalAddMailDomain.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/domains/components/ModalAddMailDomain.tsx
@@ -184,7 +184,7 @@ export const ModalAddMailDomain = () => {
                   text={
                     fieldState?.error?.message
                       ? fieldState.error.message
-                      : t('E.g. : support@saint-laurent.fr')
+                      : t('E.g. : support@example.fr')
                   }
                   {...methods.register('supportEmail')}
                 />

--- a/src/frontend/apps/desk/src/i18n/translations.json
+++ b/src/frontend/apps/desk/src/i18n/translations.json
@@ -74,7 +74,7 @@
       "Domain name": "Nom de domaine",
       "E-mail:": "E-mail:",
       "E.g. : jean.dupont@mail.fr": "Ex. : jean.dupont@mail.fr",
-      "E.g. : support@saint-laurent.fr": "Par exemple : support@saint-laurent.fr",
+      "E.g. : support@example.fr": "Par exemple : support@example.fr",
       "Email address prefix": "Préfixe de l'adresse mail",
       "Emails": "Emails",
       "Empty team icon": "Icône équipe vide",


### PR DESCRIPTION
The domain of support email suggested was
the same as the example domain name
suggested below.
This was a bit confusing because if the
domain is broken we need to contact someone
with a working email address.
