### PR TITLE
🔒️(docker) patch libssl3 and libcrypto3 to address CVE-2024-12797

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,12 @@ RUN yarn build
 # ---- Front-end image ----
 FROM nginxinc/nginx-unprivileged:1.26-alpine AS frontend-production
 
+USER root
+
+RUN apk update && apk upgrade libssl3 libcrypto3
+
+USER nginx
+
 # Un-privileged user running the application
 ARG DOCKER_USER
 USER ${DOCKER_USER}


### PR DESCRIPTION
Added temporary root privileges to update OpenSSL libraries. Upgrades libssl3 and libcrypto3 to 3.3.3-r0 to fix HIGH severity vulnerability. Properly switches back to nginx user after updates. Maintains unprivileged execution while addressing security concern affecting RFC7250 Raw Public Keys authentication.

Security: CVE-2024-12797


Fix temporaire d'Antoine [ici](https://github.com/suitenumerique/meet/commit/b5037db685803b9189f7787156a6533283114b90)