### PR TITLE
⚡️(ci) save time on CI by not downloading already present browser

### DIFF
--- a/.github/workflows/people.yml
+++ b/.github/workflows/people.yml
@@ -201,9 +201,6 @@ jobs:
         run: |
           make dimail-setup-db
 
-      - name: Install Playwright Browsers
-        run: cd src/frontend/apps/e2e && yarn install
-
       - name: Run e2e tests
         run: cd src/frontend/ && yarn e2e:test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 

--- a/src/frontend/apps/e2e/playwright.config.ts
+++ b/src/frontend/apps/e2e/playwright.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'], locale: 'en-US' },
+      use: { ...devices['Desktop Chrome'], locale: 'en-US', channel: 'chrome' },
     },
   ],
 });


### PR DESCRIPTION
## Purpose

Step labeled "Install Playwright browsers" in CI is taking at least two minutes, often longer, sometimes causing failures. It's not actually necessary as we are only using the Chromium engine and Chrome is in our base image.

## Proposal

Use Chrome that's already installed.

Inspired by https://github.com/microsoft/playwright/issues/23388