### PR TITLE
🐛(communes) add missing user creation and status in domain provisioning

### DIFF
--- a/src/backend/plugins/tests/organizations/test_commune_creation.py
+++ b/src/backend/plugins/tests/organizations/test_commune_creation.py
@@ -86,7 +86,7 @@ def test_tasks_on_commune_creation_include_dimail_domain_creation():
     tasks = plugin.complete_commune_creation(name)
 
     assert tasks[1].base == settings.MAIL_PROVISIONING_API_URL
-    assert tasks[1].url == "/domains"
+    assert tasks[1].url == "/domains/"
     assert tasks[1].method == "POST"
     assert tasks[1].params == {
         "name": "merlaut.collectivite.fr",
@@ -168,6 +168,39 @@ def test_tasks_on_commune_creation_include_dns_records():
     assert zone_call.url == "/domain/v2beta1/dns-zones/abidos.collectivite.fr/records"
     assert (
         zone_call.headers["X-Auth-Token"] == settings.DNS_PROVISIONING_API_CREDENTIALS
+    )
+
+
+def test_tasks_on_grant_access():
+    """Test the final tasks after making user admin of an org"""
+    plugin = CommuneCreation()
+
+    tasks = plugin.complete_grant_access("some-sub", "mezos.collectivite.fr")
+
+    assert tasks[0].base == settings.MAIL_PROVISIONING_API_URL
+    assert tasks[0].url == "/users/"
+    assert tasks[0].method == "POST"
+    assert tasks[0].params == {
+        "name": "some-sub",
+        "password": "no",
+        "is_admin": False,
+        "perms": [],
+    }
+    assert (
+        tasks[0].headers["Authorization"]
+        == f"Basic {settings.MAIL_PROVISIONING_API_CREDENTIALS}"
+    )
+
+    assert tasks[1].base == settings.MAIL_PROVISIONING_API_URL
+    assert tasks[1].url == "/allows/"
+    assert tasks[1].method == "POST"
+    assert tasks[1].params == {
+        "user": "some-sub",
+        "domain": "mezos.collectivite.fr",
+    }
+    assert (
+        tasks[1].headers["Authorization"]
+        == f"Basic {settings.MAIL_PROVISIONING_API_CREDENTIALS}"
     )
 
 

--- a/src/frontend/apps/e2e/__tests__/app-desk/domain-provisioning.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/domain-provisioning.spec.ts
@@ -8,7 +8,9 @@ test.beforeEach(async ({ page, browserName }) => {
 });
 
 test.describe('When a commune, domain is created on first login via ProConnect', () => {
-  test('it checks the domain has been created', async ({ page }) => {
+  test('it checks the domain has been created and is operational', async ({
+    page,
+  }) => {
     const header = page.locator('header').first();
     await expect(header.getByAltText('Marianne Logo')).toBeVisible();
 


### PR DESCRIPTION
## Purpose

Complete automated domain provisioning that was _almost_ correct 😅 

## Proposal

~~Automatically created domains are now set to active, and a user created in Dimail. Also add an E2E test showing it's possible to immediately create mailboxes on such domains.~~

Amended proposal and implementation after discussing with @sdemagny - only create the user in Dimail, leave the status as Pending (the user can rerun the check at any time), comment out the E2E test for now.