### PR TITLE
📌(renovate) ignore @hookform/resolvers until issue fixed

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
       "enabled": false,
       "groupName": "ignored js dependencies",
       "matchManagers": ["npm"],
-      "matchPackageNames": ["fetch-mock", "node", "node-fetch", "eslint"]
+      "matchPackageNames": ["fetch-mock", "node", "node-fetch", "eslint", "@hookform/resolvers"]
     }
   ]
 }


### PR DESCRIPTION
## Purpose

Get [Renovate/JS](https://github.com/suitenumerique/people/pull/735) unstuck.

## Proposal

Version 4.1.0 of @hookforms/resolvers breaks Zod resolvers, tell Renovate to ignore it until the issue is fixed.