### PR TITLE
🧑‍💻(bootstrap) install playwright browsers for local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ help:
 
 # Front 
 install-front-desk: ## Install the frontend dependencies of app Desk  
-	cd $(PATH_FRONT_DESK) && yarn
+	cd $(PATH_FRONT_DESK) && yarn && yarn playwright install chromium
 .PHONY: install-front-desk
 
 run-front-desk: ## Start app Desk  


### PR DESCRIPTION
## Purpose

Preserve developer experience (esp. for newly onboarded devs)

## Proposal

Removal of Playwright browsers installation is a win for CI but
not a reason to degrade developer experience, so we install them
locally as part of the bootstrap process.
