### PR TITLE
👽️(dimail) increase timeout value for API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 👽️(dimail) increase timeout value for API calls
+
 ## [1.12.0] - 2025-02-18
 
 ### Added

--- a/src/backend/plugins/organizations.py
+++ b/src/backend/plugins/organizations.py
@@ -101,7 +101,7 @@ class ApiCall:
                 url=f"{self.base}/{self.url}",
                 json=self.params,
                 headers=self.headers,
-                timeout=5,
+                timeout=20,
             )
         else:
             response = requests.request(
@@ -109,7 +109,7 @@ class ApiCall:
                 url=f"{self.base}/{self.url}",
                 params=self.params,
                 headers=self.headers,
-                timeout=5,
+                timeout=20,
             )
         self.response_data = response.json()
         logger.info(


### PR DESCRIPTION
## Purpose

Avoid 500s when requesting new domains from Dimail at commune creation time.

## Proposal

The domain creation endpoint will sometimes take longer than 5s to complete, so we increase timeouts.