### PR TITLE
🔧(api) allow swagger collection

### DIFF
--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -213,6 +213,7 @@ class Base(Configuration):
         "demo",
         "mailbox_manager",
         "drf_spectacular",
+        "drf_spectacular_sidecar",  # required for Django collectstatic discovery
         # Third party apps
         "corsheaders",
         "dockerflow.django",
@@ -662,7 +663,7 @@ class Development(Base):
     def __init__(self):
         """In dev, force installs needed for Swagger API."""
         # pylint: disable=invalid-name
-        self.INSTALLED_APPS += ["django_extensions", "drf_spectacular_sidecar"]
+        self.INSTALLED_APPS += ["django_extensions"]
 
 
 class Test(Base):

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "django-timezone-field>=5.1",
     "django==5.1.6",
     "djangorestframework==3.15.2",
-    "drf_spectacular==0.28.0",
+    "drf_spectacular[sidecar]==0.28.0",
     "dockerflow==2024.4.2",
     "easy_thumbnails==2.10",
     "factory_boy==3.3.3",


### PR DESCRIPTION
## Purpose

add drf_spectacular_sidecar to correctly collect swagger upon collectstatic

## Proposal

Description...

- [x] add "drf_spectacular_sidecar" for Django to correctly collect swagger upon collectstatic 
- [x] add option [sidecar] in pyproject.toml
