### PR TITLE
🐛(mailbox) fix migration to fill dn_email field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(mailbox) fix migration to fill dn_email field
+
 ## [1.13.0] - 2025-03-04
 
 ### Added

--- a/src/backend/mailbox_manager/migrations/0023_mailbox_email_mailbox_last_login_mailbox_password.py
+++ b/src/backend/mailbox_manager/migrations/0023_mailbox_email_mailbox_last_login_mailbox_password.py
@@ -12,7 +12,7 @@ def fill_dn_email(apps, schema_editor):
         models.Q(dn_email="") | models.Q(dn_email__isnull=True)
     ):
         # quite naive but we don't have many data
-        mailbox.dn_email = mailbox.get_email()
+        mailbox.dn_email = f"{mailbox.local_part}@{mailbox.domain.name}"
         mailbox.save()
 
 


### PR DESCRIPTION
Fix AttributeError
'Mailbox' object has no attribute 'get_email'