### PR TITLE
🐛(tests) change domain name factory to be more boring but reliable

### DIFF
--- a/src/backend/mailbox_manager/factories.py
+++ b/src/backend/mailbox_manager/factories.py
@@ -26,7 +26,7 @@ class MailDomainFactory(factory.django.DjangoModelFactory):
         django_get_or_create = ("name",)
         skip_postgeneration_save = True
 
-    name = factory.Faker("domain_name")
+    name = factory.Sequence(lambda n: f"domain{n!s}.com")
     slug = factory.LazyAttribute(lambda o: slugify(o.name))
     support_email = factory.Faker("email")
 


### PR DESCRIPTION
## Purpose

Avoid random CI failures unrelated to the contents of commits or PRs.

## Proposal

MailDomain fixtures now use a boring non-repeating sequence. If you ask for a batch of domains, they will be domain1.com, domain2.com, and so on. This means that MailDomainFactory.create_batch(N) will always return exactly N different names, although similar to each other.

No longer will the occasional random CI failure inject excitement into our workdays; but fear not, there will remain other occasions to enjoy the art of debugging.

Fixes #699