### PR TITLE
🔧(dns) make target zone for communes domains configurable

### DIFF
--- a/env.d/development/france.dist
+++ b/env.d/development/france.dist
@@ -1,1 +1,2 @@
 ORGANIZATION_PLUGINS=plugins.organizations.NameFromSiretOrganizationPlugin,plugins.organizations.CommuneCreation
+DNS_PROVISIONING_TARGET_ZONE=test.collectivite.fr

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -545,6 +545,11 @@ class Base(Configuration):
         environ_name="MAIL_CHECK_DOMAIN_INTERVAL",
         environ_prefix=None,
     )
+    DNS_PROVISIONING_TARGET_ZONE = values.Value(
+        default=None,
+        environ_name="DNS_PROVISIONING_TARGET_ZONE",
+        environ_prefix=None,
+    )
     DNS_PROVISIONING_API_URL = values.Value(
         default="https://api.scaleway.com",
         environ_name="DNS_PROVISIONING_API_URL",

--- a/src/backend/plugins/organizations.py
+++ b/src/backend/plugins/organizations.py
@@ -181,7 +181,7 @@ class CommuneCreation(BaseOrganizationPlugin):
     def zone_name(self, name: str) -> str:
         """Derive the zone name from the commune name"""
         normalized = self.normalize_name(name)
-        return f"{normalized}.collectivite.fr"
+        return f"{normalized}.{settings.DNS_PROVISIONING_TARGET_ZONE}"
 
     def complete_commune_creation(self, name: str) -> ApiCall:
         """Specify the tasks to be completed after a commune is created."""
@@ -193,7 +193,7 @@ class CommuneCreation(BaseOrganizationPlugin):
         create_zone.url = "/domain/v2beta1/dns-zones"
         create_zone.params = {
             "project_id": settings.DNS_PROVISIONING_RESOURCE_ID,
-            "domain": "collectivite.fr",
+            "domain": settings.DNS_PROVISIONING_TARGET_ZONE,
             "subdomain": inputs["name"],
         }
         create_zone.headers = {

--- a/src/backend/plugins/tests/organizations/test_commune_creation.py
+++ b/src/backend/plugins/tests/organizations/test_commune_creation.py
@@ -1,6 +1,7 @@
 """Tests for the CommuneCreation plugin."""
 
 from django.conf import settings
+from django.test.utils import override_settings
 
 import pytest
 import responses
@@ -60,6 +61,7 @@ def test_api_call_execution():
         task.execute()
 
 
+@override_settings(DNS_PROVISIONING_TARGET_ZONE="collectivite.fr")
 def test_tasks_on_commune_creation_include_zone_creation():
     """Test the first task in commune creation: creating the DNS sub-zone"""
     plugin = CommuneCreation()
@@ -78,6 +80,7 @@ def test_tasks_on_commune_creation_include_zone_creation():
     assert tasks[0].headers["X-Auth-Token"] == settings.DNS_PROVISIONING_API_CREDENTIALS
 
 
+@override_settings(DNS_PROVISIONING_TARGET_ZONE="collectivite.fr")
 def test_tasks_on_commune_creation_include_dimail_domain_creation():
     """Test the second task in commune creation: creating the domain in Dimail"""
     plugin = CommuneCreation()
@@ -100,6 +103,7 @@ def test_tasks_on_commune_creation_include_dimail_domain_creation():
     )
 
 
+@override_settings(DNS_PROVISIONING_TARGET_ZONE="collectivite.fr")
 def test_tasks_on_commune_creation_include_fetching_spec():
     """Test the third task in commune creation: asking Dimail for the spec"""
     plugin = CommuneCreation()
@@ -116,6 +120,7 @@ def test_tasks_on_commune_creation_include_fetching_spec():
     )
 
 
+@override_settings(DNS_PROVISIONING_TARGET_ZONE="collectivite.fr")
 def test_tasks_on_commune_creation_include_dns_records():
     """Test the next several tasks in commune creation: creating records"""
     plugin = CommuneCreation()
@@ -171,6 +176,7 @@ def test_tasks_on_commune_creation_include_dns_records():
     )
 
 
+@override_settings(DNS_PROVISIONING_TARGET_ZONE="collectivite.fr")
 def test_tasks_on_grant_access():
     """Test the final tasks after making user admin of an org"""
     plugin = CommuneCreation()
@@ -218,6 +224,7 @@ def test_normalize_name():
     )
 
 
+@override_settings(DNS_PROVISIONING_TARGET_ZONE="collectivite.fr")
 def test_zone_name():
     """Test transforming a commune name to a sub-zone of collectivite.fr"""
     plugin = CommuneCreation()

--- a/src/frontend/apps/e2e/__tests__/app-desk/domain-provisioning.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/domain-provisioning.spec.ts
@@ -23,7 +23,7 @@ test.describe('When a commune, domain is created on first login via ProConnect',
     await expect(
       page.getByLabel('Mail domains panel', { exact: true }),
     ).toBeVisible();
-    await expect(page.getByText('merlaut.collectivite.fr')).toHaveCount(1);
+    await expect(page.getByText('merlaut.test.collectivite.fr')).toHaveCount(1);
     await expect(page.getByText('No domains exist.')).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Purpose

Ease management of subdomains created for testing purposes.

## Proposal

Currently domains for communes created during testing share the same destination (collectivite.fr) as the ones created during production.

Add a configuration setting tied to an env var, so we can have a separate zone for staging/preprod.

This way it's easier to tell which subdomains are for testing and can be deleted without user impact.

Default value is None to keep code generic.