### PR TITLE
🐛(mailbox) fix mailbox creation email language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to
 - ✨(frontend) feature modal add new access role to domain 
 - ✨(api) allow invitations for domain management #708
 
+### Fixed
+
+- 🐛(mailbox) fix mailbox creation email language
+
 ## [1.13.1] - 2025-03-04
 
 ### Fixed

--- a/src/backend/mailbox_manager/api/client/serializers.py
+++ b/src/backend/mailbox_manager/api/client/serializers.py
@@ -55,7 +55,9 @@ class MailboxSerializer(serializers.ModelSerializer):
 
             # send confirmation email
             client.notify_mailbox_creation(
-                recipient=mailbox.secondary_email, mailbox_data=response.json()
+                recipient=mailbox.secondary_email,
+                mailbox_data=response.json(),
+                issuer=self.context["request"].user,
             )
 
         # actually save mailbox on our database

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_create.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_create.py
@@ -790,10 +790,14 @@ def test_api_mailboxes__sends_new_mailbox_notification(mock_info):
     Creating a new mailbox should send confirmation email
     to secondary email.
     """
-    access = factories.MailDomainAccessFactory(role=enums.MailDomainRoleChoices.OWNER)
+    user = core_factories.UserFactory(language="fr-fr")
+    access = factories.MailDomainAccessFactory(
+        user=user,
+        role=enums.MailDomainRoleChoices.OWNER,
+    )
 
     client = APIClient()
-    client.force_login(access.user)
+    client.force_login(user)
     mailbox_data = serializers.MailboxSerializer(
         factories.MailboxFactory.build(domain=access.domain)
     ).data
@@ -824,7 +828,10 @@ def test_api_mailboxes__sends_new_mailbox_notification(mock_info):
             )
 
         assert mock_send.call_count == 1
-        assert mock_send.mock_calls[0][1][0] == "Your new mailbox information"
+        assert (
+            "Informations sur votre nouvelle boîte mail"
+            in mock_send.mock_calls[0][1][1]
+        )
         assert mock_send.mock_calls[0][1][3][0] == mailbox_data["secondary_email"]
 
     expected_messages = {

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -136,7 +136,11 @@ class Base(Configuration):
     # https://docs.djangoproject.com/en/3.1/topics/i18n/
 
     # Languages
-    LANGUAGE_CODE = values.Value("en-us")
+    LANGUAGE_CODE = values.Value(
+        default="en-us",
+        environ_name="LANGUAGE_CODE",
+        environ_prefix=None,
+    )
 
     DRF_NESTED_MULTIPART_PARSER = {
         # output of parser is converted to querydict


### PR DESCRIPTION
Don't forget to translate mail content before sending.
