### PR TITLE
🐛(i18n) fix `i18n-generate` make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,7 @@ back-i18n-compile: ## compile the gettext files
 .PHONY: back-i18n-compile
 
 back-i18n-generate: ## create the .pot files used for i18n
+back-i18n-generate: crowdin-download-sources
 	@$(MANAGE) makemessages -a --keep-pot
 .PHONY: back-i18n-generate
 
@@ -269,6 +270,7 @@ i18n-compile: \
 
 i18n-generate: ## create the .pot files and extract frontend messages
 i18n-generate: \
+	crowdin-download-sources \
 	back-i18n-generate \
 	frontend-i18n-generate
 .PHONY: i18n-generate

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ back-i18n-compile: ## compile the gettext files
 .PHONY: back-i18n-compile
 
 back-i18n-generate: ## create the .pot files used for i18n
-back-i18n-generate: crowdin-download-sources
+back-i18n-generate: mails-build crowdin-download-sources
 	@$(MANAGE) makemessages -a --keep-pot
 .PHONY: back-i18n-generate
 


### PR DESCRIPTION
## Purpose

The `i18n-generate` make command was not downloading the pot from crowdin before the Django `makemessages` resulting in a pot file never updated.


## Proposal

Now:

```
> make -n i18n-generate
DOCKER_USER=1000:1000 docker compose run --rm crowdin crowdin download sources -c crowdin/config.yml
DOCKER_USER=1000:1000 docker compose run --rm app-dev python manage.py makemessages -a --keep-pot
cd ./src/frontend && yarn i18n:extract

> make -n back-i18n-generate
DOCKER_USER=1000:1000 docker compose run --rm crowdin crowdin download sources -c crowdin/config.yml
DOCKER_USER=1000:1000 docker compose run --rm app-dev python manage.py makemessages -a --keep-pot

> make -n frontend-i18n-generate
DOCKER_USER=1000:1000 docker compose run --rm crowdin crowdin download sources -c crowdin/config.yml
cd ./src/frontend && yarn i18n:extract
```
