### PR TITLE
🧑‍💻(makefile) enforce generated mail clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,11 @@ dimail-setup-db:
 
 # -- Mail generator
 
-mails-build: ## Convert mjml files to html and text
+mails-remove-templates: ## Remove the generated mail templates
+	rm -Rf "./src/backend/core/templates/mail"
+.PHONY: mails-remove-templates
+
+mails-build: mails-clean-templates ## Convert mjml files to html and text
 	@$(MAIL_YARN) build
 .PHONY: mails-build
 


### PR DESCRIPTION
## Purpose

When used locally, you may have removed templates staying and generarting old translations.


## Proposal

- [x] add `mails-remove-templates` to makefile
- [x] call `mails-remove-templates` before `mails-build`
