### PR TITLE
🐛(frontend) catch 404 for team/maildomain display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(frontend) catch 404 for team/maildomain display #808
 - 🐛(oauth2) force JWT signed for /userinfo #804
 - 🐛(oauth2) add ProConnect scopes #802
 - 🐛(domains) use a dedicated mail to invite user to manage domain

--- a/src/frontend/apps/desk/src/features/mail-domains/domains/api/useMailDomain.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/domains/api/useMailDomain.tsx
@@ -1,4 +1,5 @@
 import { UseQueryOptions, useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 
 import { APIError, errorCauses, fetchAPI } from '@/api';
 
@@ -35,9 +36,21 @@ export function useMailDomain(
     MailDomainResponse
   >,
 ) {
+  const router = useRouter();
+
   return useQuery<MailDomainResponse, APIError, MailDomainResponse>({
     queryKey: [KEY_MAIL_DOMAIN, param],
-    queryFn: () => getMailDomain(param),
+
+    queryFn: async () => {
+      try {
+        return await getMailDomain(param);
+      } catch (error) {
+        if (error instanceof APIError && error.status === 404) {
+          router.replace('/404');
+        }
+        throw error;
+      }
+    },
     ...queryConfig,
   });
 }

--- a/src/frontend/apps/desk/src/features/teams/team-management/api/useTeam.tsx
+++ b/src/frontend/apps/desk/src/features/teams/team-management/api/useTeam.tsx
@@ -1,4 +1,5 @@
 import { UseQueryOptions, useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 
 import { APIError, errorCauses, fetchAPI } from '@/api';
 
@@ -24,9 +25,20 @@ export function useTeam(
   param: TeamParams,
   queryConfig?: UseQueryOptions<Team, APIError, Team>,
 ) {
+  const router = useRouter();
+
   return useQuery<Team, APIError, Team>({
     queryKey: [KEY_TEAM, param],
-    queryFn: () => getTeam(param),
+    queryFn: async () => {
+      try {
+        return await getTeam(param);
+      } catch (error) {
+        if (error instanceof APIError && error.status === 404) {
+          router.replace('/404');
+        }
+        throw error;
+      }
+    },
     ...queryConfig,
   });
 }


### PR DESCRIPTION
## Purpose

When the API returns a 404, the API is called again twice (three calls), this make the 404 display quite long and calling the API for nothing.

The solution here is a patch, I didn't find the root cause of that.


## Proposal

- [x] catch the 404 at the `useQuery` level
