### PR TITLE
🧐(stats) restrict domains count to active domains

### DIFF
--- a/src/backend/core/api/client/viewsets.py
+++ b/src/backend/core/api/client/viewsets.py
@@ -29,6 +29,7 @@ from core.api import permissions
 from core.api.client import serializers
 from core.utils.raw_sql import gen_sql_filter_json_array
 
+from mailbox_manager import enums
 from mailbox_manager import models as domains_models
 
 
@@ -609,7 +610,9 @@ class StatView(views.APIView):
                 last_login__gte=timezone.now() - datetime.timedelta(30)
             ).count(),
             "teams": models.Team.objects.count(),
-            "domains": domains_models.MailDomain.objects.count(),
+            "domains": domains_models.MailDomain.objects.filter(
+                status=enums.MailDomainStatusChoices.ENABLED
+            ).count(),
             "mailboxes": domains_models.Mailbox.objects.count(),
         }
         return response.Response(context)

--- a/src/backend/core/tests/test_api_stats.py
+++ b/src/backend/core/tests/test_api_stats.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.django_db
 def test_api_stats__anonymous(django_assert_num_queries):
     """Stats endpoint should be available even when not connected."""
 
-    domains_factories.MailDomainFactory.create_batch(5)
+    domains_factories.MailDomainEnabledFactory.create_batch(5)
     core_factories.TeamFactory.create_batch(3)
 
     # clear cache to allow stats count
@@ -57,7 +57,8 @@ def test_api_stats__expected_count():
         client.force_login(user)
 
     core_factories.TeamFactory.create_batch(3)
-    domains_factories.MailDomainFactory.create_batch(2)
+    domains_factories.MailDomainFactory.create_batch(1)
+    domains_factories.MailDomainEnabledFactory.create_batch(2)
     domains_factories.MailboxFactory.create_batch(
         10, domain=domains_models.MailDomain.objects.all()[1]
     )


### PR DESCRIPTION
## Purpose

Stats are currently counting all domains, including users tests. Counting enabled domains is more relevant to reflect actual use.
