### PR TITLE
♻️(dimail) refacto setup_dimail_db to call dimail client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ recreate-dimail-container:
 
 dimail-setup-db:
 	@echo "$(BOLD)Populating database of local dimail API container$(RESET)"
-	@$(MANAGE) setup_dimail_db
+	@$(MANAGE) setup_dimail_db --populate-from-people
 .PHONY: dimail-setup-db
 
 # -- Mail generator

--- a/src/backend/mailbox_manager/management/commands/setup_dimail_db.py
+++ b/src/backend/mailbox_manager/management/commands/setup_dimail_db.py
@@ -9,6 +9,7 @@ from rest_framework import status
 
 from mailbox_manager import enums
 from mailbox_manager.models import MailDomain, MailDomainAccess
+from mailbox_manager.utils.dimail import DimailAPIClient
 
 User = get_user_model()
 
@@ -22,6 +23,8 @@ class Command(BaseCommand):
     """
     Management command populate local dimail database, to ease dev
     """
+
+    client = DimailAPIClient()
 
     help = "Populate local dimail database, for dev purposes."
 
@@ -84,7 +87,7 @@ class Command(BaseCommand):
         else:
             # create accesses for john doe
             self.create_user(name=people_base_user.sub)
-            self.create_allows(people_base_user.sub, domain_name)
+            self.create_allow(people_base_user.sub, domain_name)
             MailDomainAccess.objects.get_or_create(
                 user=people_base_user,
                 domain=domain,
@@ -128,20 +131,11 @@ class Command(BaseCommand):
                 )
             )
 
-    def create_domain(self, name, auth=(regie["username"], regie["password"])):
+    def create_domain(self, name):
         """
-        Send a request to create a new domain.
+        Send a request to create a new domain using DimailAPIClient.
         """
-        response = requests.post(
-            url=f"{DIMAIL_URL}/domains/",
-            json={
-                "name": name,
-                "context_name": "context",
-                "features": ["webmail", "mailbox", "alias"],
-            },
-            auth=auth,
-            timeout=10,
-        )
+        response = self.client.create_domain(name, request_user="script_setup")
 
         if response.status_code == status.HTTP_201_CREATED:
             self.stdout.write(
@@ -154,19 +148,11 @@ class Command(BaseCommand):
                 )
             )
 
-    def create_allows(self, user, domain, auth=(regie["username"], regie["password"])):
+    def create_allow(self, user, domain):
         """
-        Send a request to create a new allows between user and domain.
+        Send a request to create a new allows between user and domain using DimailAPIClient.
         """
-        response = requests.post(
-            url=f"{DIMAIL_URL}/allows/",
-            json={
-                "domain": domain,
-                "user": user,
-            },
-            auth=auth,
-            timeout=10,
-        )
+        response = self.client.create_allow(user, domain)
 
         if response.status_code == status.HTTP_201_CREATED:
             self.stdout.write(
@@ -216,4 +202,4 @@ class Command(BaseCommand):
 
         # create missing accesses
         for access in access_to_create:
-            self.create_allows(access.user.sub, access.domain.name)
+            self.create_allow(access.user.sub, access.domain.name)

--- a/src/backend/mailbox_manager/tests/commands/test_dimail_setup_db.py
+++ b/src/backend/mailbox_manager/tests/commands/test_dimail_setup_db.py
@@ -74,8 +74,9 @@ def test_commands_setup_dimail_db(settings):
 
     assert responses.calls[2].request.url == f"{DIMAIL_URL}/domains/"
     assert responses.calls[2].request.body == (
-        b'{"name": "test.domain.com", "context_name": "context", '
-        b'"features": ["webmail", "mailbox", "alias"]}'
+        b'{"name": "test.domain.com", "context_name": "test.domain.com", '
+        b'"features": ["webmail", "mailbox", "alias"], '
+        b'"delivery": "virtual"}'
     )
 
     assert responses.calls[3].request.url == f"{DIMAIL_URL}/users/"
@@ -87,7 +88,7 @@ def test_commands_setup_dimail_db(settings):
     assert responses.calls[4].request.url == f"{DIMAIL_URL}/allows/"
     assert (
         responses.calls[4].request.body
-        == b'{"domain": "test.domain.com", "user": "sub.john.doe"}'
+        == b'{"user": "sub.john.doe", "domain": "test.domain.com"}'
     )
 
     # reset the responses counter
@@ -112,8 +113,9 @@ def test_commands_setup_dimail_db(settings):
     assert (
         f"{DIMAIL_URL}/domains/",
         (
-            b'{"name": "some.domain.com", "context_name": "context", '
-            b'"features": ["webmail", "mailbox", "alias"]}'
+            b'{"name": "some.domain.com", "context_name": "some.domain.com", '
+            b'"features": ["webmail", "mailbox", "alias"], '
+            b'"delivery": "virtual"}'
         ),
     ) in dimail_calls
 
@@ -124,5 +126,5 @@ def test_commands_setup_dimail_db(settings):
 
     assert (
         f"{DIMAIL_URL}/allows/",
-        b'{"domain": "some.domain.com", "user": "sub.toto.123"}',
+        b'{"user": "sub.toto.123", "domain": "some.domain.com"}',
     ) in dimail_calls

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -86,7 +86,7 @@ class DimailAPIClient:
         payload = {
             "name": domain_name,
             "context_name": domain_name,  # for now, we put each domain on its own context
-            "features": ["webmail", "mailbox"],
+            "features": ["webmail", "mailbox", "alias"],
             "delivery": "virtual",
         }
         try:
@@ -115,7 +115,7 @@ class DimailAPIClient:
 
         return self.raise_exception_for_unexpected_response(response)
 
-    def create_mailbox(self, mailbox, user_sub=None):
+    def create_mailbox(self, mailbox, request_user=None):
         """Send a CREATE mailbox request to mail provisioning API."""
 
         payload = {
@@ -126,7 +126,7 @@ class DimailAPIClient:
             # displayName value has to be unique
             "displayName": f"{mailbox.first_name} {mailbox.last_name}",
         }
-        headers = self.get_headers(user_sub)
+        headers = self.get_headers(request_user)
 
         try:
             response = session.post(
@@ -148,7 +148,7 @@ class DimailAPIClient:
             logger.info(
                 "Mailbox successfully created on domain %s by user %s",
                 str(mailbox.domain),
-                user_sub,
+                request_user,
             )
             return response
 


### PR DESCRIPTION
## Purpose

Management command "setup_dimail_db" called dimail directly, thus creating duplicated code. It now calls "create_domain" and "create_allow" methods from DimailAPIClient (create_user is left unchanged to create special users such as dimail admin or people)


## Proposal

Description...

- [x] use create_allow and create_domain from DimailAPIClient
- [x] fixed inconsistencies in tests


I keep using setup_dimail_db's "create_user" because it allows for admin=True for admin user and for special perms for people user. Client's method on the contrary, does not, which makes sense because we want all the dimail users created from people to be basic (== admin=False + perms = []). 

Rather than modifying client's method, I sticked to the one in setup_dimail_db but we can discuss that.

