### PR TITLE
✨(dimail) allow to reset the mailbox password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(mailbox) allow to reset password on mailboxes #834
+
 ## [1.16.0] - 2025-05-05
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,7 +173,7 @@ services:
 
   dimail: 
     entrypoint: /opt/dimail-api/start-dev.sh
-    image: registry.mim-libre.fr/dimail/dimail-api:v0.1.1
+    image: registry.mim-libre.fr/dimail/dimail-api:v0.2.11
     pull_policy: always
     environment:
       DIMAIL_MODE: FAKE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,7 @@ services:
 
   dockerize:
     image: jwilder/dockerize
+    platform: linux/x86_64
 
   crowdin:
     image: crowdin/cli:4.6.1

--- a/src/backend/mailbox_manager/api/client/viewsets.py
+++ b/src/backend/mailbox_manager/api/client/viewsets.py
@@ -293,6 +293,15 @@ class MailBoxViewSet(
         mailbox.save()
         return Response(serializers.MailboxSerializer(mailbox).data)
 
+    @action(detail=True, methods=["post"])
+    def reset_password(self, request, domain_slug, pk=None):  # pylint: disable=unused-argument
+        """Send a request to dimail to change password
+        and email new password to mailbox's secondary email."""
+        mailbox = self.get_object()
+        dimail = DimailAPIClient()
+        dimail.reset_password(mailbox)
+        return Response(serializers.MailboxSerializer(mailbox).data)
+
 
 class MailDomainInvitationViewset(
     mixins.CreateModelMixin,

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_reset_password.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_reset_password.py
@@ -1,0 +1,183 @@
+"""
+Unit tests for the reset password mailbox API
+"""
+
+from unittest import mock
+
+from django.conf import settings
+
+import pytest
+import responses
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core import factories as core_factories
+
+from mailbox_manager import enums, factories
+from mailbox_manager.tests.fixtures import dimail
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_mailboxes__reset_password_anonymous_unauthorized():
+    """Anonymous users should not be able to reset mailboxes password."""
+    mailbox = factories.MailboxFactory(status=enums.MailboxStatusChoices.ENABLED)
+    response = APIClient().post(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/reset_password/",
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_api_mailboxes__reset_password_unrelated_forbidden():
+    """Authenticated users not managing the domain
+    should not be able to reset its mailboxes password."""
+    user = core_factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    mailbox = factories.MailboxFactory(status=enums.MailboxStatusChoices.ENABLED)
+
+    response = client.post(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/reset_password/"
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {
+        "detail": "You do not have permission to perform this action."
+    }
+
+
+def test_api_mailboxes__reset_password_viewer_forbidden():
+    """Domain viewers should not be able to reset passwords on mailboxes."""
+    mailbox = factories.MailboxEnabledFactory()
+    viewer_access = factories.MailDomainAccessFactory(
+        role=enums.MailDomainRoleChoices.VIEWER, domain=mailbox.domain
+    )
+
+    client = APIClient()
+    client.force_login(viewer_access.user)
+
+    response = client.post(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/reset_password/"
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {
+        "detail": "You do not have permission to perform this action."
+    }
+
+
+def test_api_mailboxes__reset_password_no_secondary_email():
+    """Should not try to reset password if no secondary email is specified."""
+    mail_domain = factories.MailDomainEnabledFactory()
+    access = factories.MailDomainAccessFactory(
+        role=enums.MailDomainRoleChoices.OWNER, domain=mail_domain
+    )
+    client = APIClient()
+    client.force_login(access.user)
+
+    error = "Password reset requires a secondary email address. \
+Please add a valid secondary email before trying again."
+
+    # Mailbox with no secondary email
+    mailbox = factories.MailboxEnabledFactory(domain=mail_domain, secondary_email=None)
+    response = client.post(
+        f"/api/v1.0/mail-domains/{mail_domain.slug}/mailboxes/{mailbox.pk}/reset_password/"
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == [error]
+
+    # Mailbox with empty secondary email
+    mailbox = factories.MailboxEnabledFactory(domain=mail_domain, secondary_email="")
+    response = client.post(
+        f"/api/v1.0/mail-domains/{mail_domain.slug}/mailboxes/{mailbox.pk}/reset_password/"
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == [error]
+
+    # Mailbox with primary email as secondary email
+    mailbox = factories.MailboxEnabledFactory(domain=mail_domain)
+    mailbox.secondary_email = str(mailbox)
+    mailbox.save()
+    response = client.post(
+        f"/api/v1.0/mail-domains/{mail_domain.slug}/mailboxes/{mailbox.pk}/reset_password/"
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == [error]
+
+
+@pytest.mark.parametrize(
+    "role",
+    [
+        enums.MailDomainRoleChoices.OWNER,
+        enums.MailDomainRoleChoices.ADMIN,
+    ],
+)
+@responses.activate
+def test_api_mailboxes__reset_password_admin_successful(role):
+    """Owner and admin users should be able to reset password on mailboxes.
+    New password should be sent to secondary email."""
+    mail_domain = factories.MailDomainEnabledFactory()
+    mailbox = factories.MailboxEnabledFactory(domain=mail_domain)
+
+    access = factories.MailDomainAccessFactory(role=role, domain=mail_domain)
+    client = APIClient()
+    client.force_login(access.user)
+    dimail_url = settings.MAIL_PROVISIONING_API_URL
+
+    responses.add(
+        responses.POST,
+        f"{dimail_url}/domains/{mail_domain.name}/mailboxes/{mailbox.local_part}/reset_password/",
+        body=dimail.response_mailbox_created(str(mailbox)),
+        status=200,
+    )
+    with mock.patch("django.core.mail.send_mail") as mock_send:
+        response = client.post(
+            f"/api/v1.0/mail-domains/{mail_domain.slug}/mailboxes/{mailbox.pk}/reset_password/"
+        )
+
+        assert mock_send.call_count == 1
+        assert "Your password has been updated" in mock_send.mock_calls[0][1][1]
+        assert mock_send.mock_calls[0][1][3][0] == mailbox.secondary_email
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_api_mailboxes__reset_password_non_existing():
+    """
+    User gets a 404 when trying to reset password of mailbox which does not exist.
+    """
+    user = core_factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.get("/api/v1.0/mail-domains/nonexistent.domain/mailboxes/")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@responses.activate
+def test_api_mailboxes__reset_password_connexion_failed():
+    """
+    No mail is sent when password reset failed because of connexion error.
+    """
+    mail_domain = factories.MailDomainEnabledFactory()
+    mailbox = factories.MailboxEnabledFactory(domain=mail_domain)
+
+    access = factories.MailDomainAccessFactory(
+        role=enums.MailDomainRoleChoices.OWNER, domain=mail_domain
+    )
+    client = APIClient()
+    client.force_login(access.user)
+
+    dimail_url = settings.MAIL_PROVISIONING_API_URL
+    responses.add(
+        responses.POST,
+        f"{dimail_url}/domains/{mail_domain.name}/mailboxes/{mailbox.local_part}/reset_password/",
+        body=ConnectionError(),
+    )
+
+    with pytest.raises(ConnectionError):
+        with mock.patch("django.core.mail.send_mail") as mock_send:
+            client.post(
+                f"/api/v1.0/mail-domains/{mail_domain.slug}/mailboxes/{mailbox.pk}/reset_password/"
+            )
+        assert mock_send.call_count == 0

--- a/src/mail/mjml/reset_password.mjml
+++ b/src/mail/mjml/reset_password.mjml
@@ -10,12 +10,11 @@
       </mj-section>
       <mj-section mj-class="bg--white-100" padding="0px 20px">
         <mj-column>
-          <!-- Welcome Message -->
-          <mj-text font-size="30px"><b>{% trans "Welcome to La Messagerie" %}</b></mj-text>
-          <mj-text>{% trans "La Messagerie is the email solution of La Suite." %}</mj-text>
+          <!-- Message -->
+          <mj-text font-size="30px"><b>{% trans "Your password has been reset" %}</b></mj-text>
           <!-- Main Message -->
-          <mj-text>{% trans "Your mailbox has been created." %}</mj-text>
-          <mj-text>{% trans "Please find below your login info: " %}</mj-text>
+          <mj-text>{% trans "Your password has been reset." %}</mj-text>
+          <mj-text>{% trans "Please find below your new login information: " %}</mj-text>
         </mj-column>
       </mj-section>
       <mj-section background-color="#f3f2fe" padding="0px 20px">


### PR DESCRIPTION
## Purpose

We want domain admins and owners to be able to reset the password for a given mailbox on their domain. New password is randomly generated by dimail and sent to mailbox's secondary email.

## Proposal

Description...

- [x] update dimail to 2.11 
- [x] add API feature
- [x] add tests
- [x] add notification email template
- [x] add notification email method
- [ ] add button in front (in this PR or future ?)
