### PR TITLE
🐛(front) disable retries in useQuery and useInfiniteQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to
 - ✨(oidc) add simple introspection backend #832
 - 🧑‍💻(tasks) run management commands #814
 
+### Fixed
+
+- 🐛(oauth2) force JWT signed for /userinfo #804
+- 🐛(front) disable retries in useQuery and useInfiniteQuery #818
+
 ## [1.14.1] - 2025-03-17
 
 ## [1.14.0] - 2025-03-17

--- a/src/frontend/apps/desk/src/features/mail-domains/domains/api/useMailDomains.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/domains/api/useMailDomains.tsx
@@ -66,6 +66,7 @@ export function useMailDomains(
     getNextPageParam(lastPage, allPages) {
       return lastPage.next ? allPages.length + 1 : undefined;
     },
+    retry: 0,
     ...queryConfig,
   });
 }

--- a/src/frontend/apps/desk/src/features/teams/team-management/api/useTeams.tsx
+++ b/src/frontend/apps/desk/src/features/teams/team-management/api/useTeams.tsx
@@ -34,5 +34,6 @@ export function useTeams(params: TeamsParams) {
   return useQuery({
     queryKey: [KEY_LIST_TEAM, params],
     queryFn: () => getTeams(params),
+    retry: 0,
   });
 }

--- a/src/frontend/apps/e2e/__tests__/app-desk/mail-domain.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/mail-domain.spec.ts
@@ -136,9 +136,7 @@ test.describe('Mail domain', () => {
       page.getByText(
         'It seems that the page you are looking for does not exist or cannot be displayed correctly.',
       ),
-    ).toBeVisible({
-      timeout: 15000,
-    });
+    ).toBeVisible();
   });
 
   test.describe('user is administrator or owner', () => {

--- a/src/frontend/apps/e2e/__tests__/app-desk/mail-domains-add.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/mail-domains-add.spec.ts
@@ -154,8 +154,6 @@ test.describe('Add Mail Domains', () => {
       page.getByText(
         'It seems that the page you are looking for does not exist or cannot be displayed correctly.',
       ),
-    ).toBeVisible({
-      timeout: 15000,
-    });
+    ).toBeVisible();
   });
 });

--- a/src/frontend/apps/e2e/__tests__/app-desk/teams-create.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/teams-create.spec.ts
@@ -99,8 +99,6 @@ test.describe('Teams Create', () => {
       page.getByText(
         'It seems that the page you are looking for does not exist or cannot be displayed correctly.',
       ),
-    ).toBeVisible({
-      timeout: 15000,
-    });
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Purpose

Unblock #818 at least partially; improve functionality for end users; improve E2E tests.

## Proposal

Bug initially noticed by @elvoisin during #818 - when a nonsense value is substituted for the slug in a URL such as `/teams/rocket`, we intercept the error state and redirect to a 404 page. However, this only occurs after 4 calls are made to the underlying API (`/api/v1.0/teams` for instance) with increasingly long delays between calls. As a result, the E2E tests could only pass with an awkwardly long timeout inserted. For some reason (which I've not fully investigated), our rework of the UI was apparently making things even worse.

This turns out to have been a result of TanStack's "[aggressive but sane defaults](https://tanstack.com/query/v4/docs/framework/react/guides/important-defaults)", and setting the `retry` parameter to 0 immediately eliminated the delays. The default options in TanStack Query don't make sense for these purposes: if we get a 404, we will always get a 404, ditto 401, and arguably ditto 500s - at least in our context. (If it ever does make sense we can always pass a higher value for retry.)

The testing side of this PR consists of eliminating the timeouts. (Personal aside: I consider timeouts in Playwright as a testing smell.)
