### PR TITLE
➖(dimail) remove ci-time dependency on dimail to improve CI times

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,6 @@ services:
       - ./data/media:/data/media
       - ./data/static:/data/static
     depends_on:
-        - dimail
         - postgresql
         - maildev
         - redis


### PR DESCRIPTION
## Purpose

Make CI shorter and more reliable.

## Proposal

Remove `dimail` as a dependency of `app-dev` in `docker-compose`. The Gitlab instance hosting dimail images has become unstable resulting in excessive CI failures, and we don't actually depend on dimail for CI.
