### PR TITLE
🔒️(users) restrict listable users to same organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 ### Changed
 
 - ♻️(plugins) rewrite plugin system as django app #844
+- 🔒️(users) restrict listable users to same organization #846 
 
 ### Fixed
 

--- a/docker/auth/realm.json
+++ b/docker/auth/realm.json
@@ -50,6 +50,9 @@
       "firstName": "John",
       "lastName": "Doe",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -81,6 +84,9 @@
       "firstName": "E2E",
       "lastName": "Chromium",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -95,6 +101,9 @@
       "firstName": "E2E",
       "lastName": "Webkit",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -109,6 +118,9 @@
       "firstName": "E2E",
       "lastName": "Firefox",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -123,6 +135,9 @@
       "firstName": "E2E",
       "lastName": "Group Member",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -137,6 +152,9 @@
       "firstName": "E2E",
       "lastName": "Group Administrator",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -151,6 +169,9 @@
       "firstName": "E2E",
       "lastName": "Group Owner",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -165,6 +186,9 @@
       "firstName": "E2E",
       "lastName": "Mailbox Member",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -179,6 +203,9 @@
       "firstName": "E2E",
       "lastName": "Mailbox Administrator",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -193,6 +220,9 @@
       "firstName": "E2E",
       "lastName": "Mailbox Owner",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -207,6 +237,9 @@
       "firstName": "E2E",
       "lastName": "Group Member Mailbox Member",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -221,6 +254,9 @@
       "firstName": "E2E",
       "lastName": "Group Member Mailbox Administrator",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -235,6 +271,9 @@
       "firstName": "E2E",
       "lastName": "Group Member Mailbox Owner",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -249,6 +288,9 @@
       "firstName": "E2E",
       "lastName": "Group Administrator Mailbox Member",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -263,6 +305,9 @@
       "firstName": "E2E",
       "lastName": "Group Administrator Mailbox Administrator",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -277,6 +322,9 @@
       "firstName": "E2E",
       "lastName": "Group Administrator Mailbox Owner",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -291,6 +339,9 @@
       "firstName": "E2E",
       "lastName": "Group Owner Mailbox Member",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -305,6 +356,9 @@
       "firstName": "E2E",
       "lastName": "Group Owner Mailbox Administrator",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",
@@ -319,6 +373,9 @@
       "firstName": "E2E",
       "lastName": "Mailbox Owner",
       "enabled": true,
+      "attributes": {
+          "siret": "13002526500013"
+      },
       "credentials": [
         {
           "type": "password",

--- a/src/backend/core/api/client/viewsets.py
+++ b/src/backend/core/api/client/viewsets.py
@@ -263,9 +263,10 @@ class UserViewSet(
         queryset = self.queryset
 
         if self.action == "list":
-            # Exclude inactive contacts
+            # Filter active users
+            # and users from same organization
             queryset = queryset.filter(
-                is_active=True,
+                is_active=True, organization_id=self.request.user.organization_id
             )
 
             # Exclude all users already in the given team

--- a/src/backend/demo/management/commands/create_demo.py
+++ b/src/backend/demo/management/commands/create_demo.py
@@ -201,6 +201,10 @@ def create_demo(stdout):  # pylint: disable=too-many-locals
             )
         # this is a quick fix to fix e2e tests
         # tests needs some no random data
+        organization, _created = models.Organization.objects.get_or_create(
+            name="13002526500013",
+            registration_id_list=["13002526500013"],
+        )
         queue.push(
             models.User(
                 sub=uuid4(),
@@ -210,6 +214,7 @@ def create_demo(stdout):  # pylint: disable=too-many-locals
                 is_superuser=False,
                 is_active=True,
                 is_staff=False,
+                organization=organization,
                 language=random.choice(settings.LANGUAGES)[0],
             )
         )
@@ -222,6 +227,7 @@ def create_demo(stdout):  # pylint: disable=too-many-locals
                 is_superuser=False,
                 is_active=True,
                 is_staff=False,
+                organization=organization,
                 language=random.choice(settings.LANGUAGES)[0],
             )
         )


### PR DESCRIPTION
## Purpose

This is a quick fix to a security issue. Previously, any user could list all users. Now /users/ endpoint only lists users from same organization.

We might improve this filter later but a quick fix would be good.

## Proposal

Description...

- [x] filter users to list only users from same organization
- [x] fix related tests
