### PR TITLE
🐛(dimail) enhance sentry log for dimail error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(dimail) enhance sentry log
 - 🐛(oauth2) force JWT signed for /userinfo #804
 - 🐛(front) disable retries in useQuery and useInfiniteQuery #818
 

--- a/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_create.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_create.py
@@ -406,5 +406,5 @@ def test_api_mail_domains__no_creation_when_dimail_duplicate(caplog):
     assert record.levelname == "ERROR"
     assert (
         record.message
-        == "[DIMAIL] unexpected error : 409 {'detail': 'Domain already exists'}"
+        == "[DIMAIL] unexpected error: 409 {'detail': 'Domain already exists'}"
     )

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_create.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_create.py
@@ -721,7 +721,7 @@ def test_api_mailboxes__handling_dimail_unexpected_error(caplog):
         assert caplog.records[0].levelname == "ERROR"
         assert (
             caplog.records[0].message
-            == "[DIMAIL] unexpected error : 500 {'detail': 'Internal server error'}"
+            == "[DIMAIL] unexpected error: 500 {'detail': 'Internal server error'}"
         )
 
 

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -251,15 +251,8 @@ class DimailAPIClient:
         except json.decoder.JSONDecodeError:
             error_content = response.content.decode(response.encoding)
 
-        logger.exception(
-            "[DIMAIL] unexpected error : %s %s",
-            response.status_code,
-            error_content,
-            exc_info=False,
-        )
         raise requests.exceptions.HTTPError(
-            f"Unexpected response from dimail: {response.status_code} "
-            f"{error_content.get('detail') or error_content}"
+            f"[DIMAIL] unexpected error: {response.status_code} {error_content}"
         )
 
     def notify_mailbox_creation(self, recipient, mailbox_data, issuer=None):


### PR DESCRIPTION
Remove duplicate sentry log and fix failure if response content has an unexpected format
