### PR TITLE
🔒️(passwords) add validators for production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- 🔒️(passwords) add validators for production #850
 - ✨(domains) allow to re-run check on domain if status is failed
 - ✨(organization) add `is_active` field
 - ✨(domains) notify support when domain status changes #668

--- a/src/backend/core/tests/test_password_validators.py
+++ b/src/backend/core/tests/test_password_validators.py
@@ -1,0 +1,50 @@
+"""Test the production settings for password validation is correct."""
+
+from django.contrib.auth.password_validation import (
+    get_default_password_validators,
+    validate_password,
+)
+
+import pytest
+
+from core.factories import UserFactory
+
+from people.settings import Production
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(name="use_production_password_validators")
+def use_production_password_validators_fixture(settings):
+    """Set the production password validators."""
+    settings.AUTH_PASSWORD_VALIDATORS = Production.AUTH_PASSWORD_VALIDATORS
+
+    get_default_password_validators.cache_clear()
+    assert len(get_default_password_validators()) == 5
+
+    yield
+
+    get_default_password_validators.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "password, error",
+    [
+        ("password", "This password is too common."),
+        ("password123", "This password is too common."),
+        ("123", "This password is too common."),
+        ("coucou", "This password is too common."),
+        ("john doe 123", "The password is too similar to the name"),
+    ],
+)
+def test_validate_password_validator(
+    use_production_password_validators,  # pylint: disable=unused-argument
+    password,
+    error,
+):
+    """Test the Mailbox password validation."""
+    user = UserFactory(name="John Doe")
+
+    with pytest.raises(Exception) as excinfo:
+        validate_password(password, user)
+    assert error in str(excinfo.value)

--- a/src/backend/mailbox_manager/tests/test_password_validators.py
+++ b/src/backend/mailbox_manager/tests/test_password_validators.py
@@ -1,0 +1,59 @@
+"""Test the production settings for password validation is correct."""
+
+from django.contrib.auth.password_validation import (
+    get_default_password_validators,
+    validate_password,
+)
+
+import pytest
+
+from mailbox_manager.factories import MailboxFactory
+from people.settings import Production
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(name="use_production_password_validators")
+def use_production_password_validators_fixture(settings):
+    """Set the production password validators."""
+    settings.AUTH_PASSWORD_VALIDATORS = Production.AUTH_PASSWORD_VALIDATORS
+
+    get_default_password_validators.cache_clear()
+    assert len(get_default_password_validators()) == 5
+
+    yield
+
+    get_default_password_validators.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "password, error",
+    [
+        ("password", "This password is too common."),
+        ("password123", "This password is too common."),
+        ("123", "This password is too common."),
+        ("coucou", "This password is too common."),
+        ("john doe 123", "The password is too similar to the"),
+    ],
+)
+def test_validate_password_validator(
+    use_production_password_validators,  # pylint: disable=unused-argument
+    password,
+    error,
+):
+    """Test the Mailbox password validation."""
+    mailbox_1 = MailboxFactory(
+        first_name="John",
+        last_name="Doe",
+    )
+    mailbox_2 = MailboxFactory(
+        local_part="john.doe",
+    )
+
+    with pytest.raises(Exception) as excinfo:
+        validate_password(password, mailbox_1)
+    assert error in str(excinfo.value)
+
+    with pytest.raises(Exception) as excinfo:
+        validate_password(password, mailbox_2)
+    assert error in str(excinfo.value)

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "django-storages==1.14.5",
     "django-timezone-field>=5.1",
     "django-treebeard==4.7.1",
+    "django-zxcvbn-password-validator==1.4.5",
     "django==5.1.7",
     "djangorestframework==3.15.2",
     "dockerflow==2024.4.2",


### PR DESCRIPTION
## Purpose

This enabled various password validators to enforce password complexity.

## Proposal

Add password validators, but only for "production" environments.

- [x] Add default Django `AUTH_PASSWORD_VALIDATORS`
- [x] Add `zxcvbn` password strength validator

Note, we may remove some of the default Django validators (except the `UserAttributeSimilarityValidator`), but I guess it's ok like this.