### PR TITLE
✨(domains) allow to re-run check on failed domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- ✨(domains) allow to re-run check on domain if status is failed
 - ✨(organization) add `is_active` field
 - ✨(domains) notify support when domain status changes #668
 - ✨(domains) define domain check interval as a settings

--- a/src/frontend/apps/desk/src/features/mail-domains/domains/components/MailDomainView.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/domains/components/MailDomainView.tsx
@@ -228,6 +228,24 @@ export const MailDomainView = ({ mailDomain, onMailDomainUpdate }: Props) => {
                 {t('Actions required')}
               </button>
             )}
+            {mailDomain?.status === 'failed' && (
+              <button
+                onClick={handleShowModal}
+                style={{
+                  padding: '5px 10px',
+                  marginLeft: '10px',
+                  backgroundColor: '#e1000f',
+                  border: 'none',
+                  color: 'white',
+                  cursor: 'pointer',
+                  fontWeight: '500',
+                  borderRadius: '5px',
+                }}
+                data-modal="mail-domain-status"
+              >
+                {t('Failed')}
+              </button>
+            )}
           </Box>
         </Box>
         <CustomTabs tabs={tabs} />


### PR DESCRIPTION
In use we realize that it is also necessary to be able to re-run dimail check on domain failed
