### PR TITLE
🐛(stats) rename stat for clarity

### DIFF
--- a/src/backend/core/api/client/viewsets.py
+++ b/src/backend/core/api/client/viewsets.py
@@ -610,7 +610,7 @@ class StatView(views.APIView):
                 last_login__gte=timezone.now() - datetime.timedelta(30)
             ).count(),
             "teams": models.Team.objects.count(),
-            "domains": domains_models.MailDomain.objects.filter(
+            "active_domains": domains_models.MailDomain.objects.filter(
                 status=enums.MailDomainStatusChoices.ENABLED
             ).count(),
             "mailboxes": domains_models.Mailbox.objects.count(),

--- a/src/backend/core/tests/test_api_stats.py
+++ b/src/backend/core/tests/test_api_stats.py
@@ -30,7 +30,7 @@ def test_api_stats__anonymous(django_assert_num_queries):
     assert response.json() == {
         "total_users": 0,
         "mau": 0,
-        "domains": 5,
+        "active_domains": 5,
         "mailboxes": 0,
         "teams": 3,
     }
@@ -41,7 +41,7 @@ def test_api_stats__anonymous(django_assert_num_queries):
     assert response.json() == {
         "total_users": 0,
         "mau": 0,
-        "domains": 5,
+        "active_domains": 5,
         "mailboxes": 0,
         "teams": 3,
     }
@@ -70,7 +70,7 @@ def test_api_stats__expected_count():
     assert response.json() == {
         "total_users": 10,
         "mau": 6,
-        "domains": 2,
+        "active_domains": 2,
         "mailboxes": 10,
         "teams": 3,
     }


### PR DESCRIPTION
## Purpose

Public statistics on domains was modified to count only enabled domains. Modify stat name to reflect change.


## Proposal

Description...

- [x] rename stat on both enpoind and tests