### PR TITLE
🐛(ci) remove path to trigger relaese helm chart

### DIFF
--- a/.github/workflows/release-helmchart.yml
+++ b/.github/workflows/release-helmchart.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - 'main'
-    paths:
-      - ./src/helm/desk/**
 
 jobs:
   release:


### PR DESCRIPTION
We had an issue with the automatic helm chart releaser so we decide to trigger the job on every merge.