### PR TITLE
🔧(renovate) add dimail-api to renovate scope

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,11 @@
       "groupName": "ignored js dependencies",
       "matchManagers": ["npm"],
       "matchPackageNames": ["fetch-mock", "node", "node-fetch", "eslint", "@hookform/resolvers"]
+    },
+    {
+      "groupName": "docker-compose dependencies",
+      "matchManagers": ["docker-compose"],
+      "matchPackageNames": ["dimail-api"]
     }
   ]
 }


### PR DESCRIPTION
## Purpose

Dimail-api is currently outside of renovate' scope, which resulted in us having to check and update dimail's image manually or, if failing to, discovering new behaviors by chance or by errors in production. This should fix it.

## Proposal

Description...

- [x] add dimail to renovate scope
