### PR TITLE
🛂(dimail) request as people

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Changed
 
+- 🛂(dimail) simplify interop with dimail
 - ✨(mailbox) remove secondary email as required field
 
 ## [1.15.0] - 2025-04-04

--- a/Makefile
+++ b/Makefile
@@ -290,9 +290,9 @@ i18n-generate-and-upload: \
 # -- INTEROPERABILTY
 # -- Dimail configuration
 
-recreate-dimail-container:
+dimail-recreate-container:
 	@$(COMPOSE) up --force-recreate -d dimail
-.PHONY: recreate-dimail-container
+.PHONY: dimail-recreate-container
 
 dimail-setup-db:
 	@echo "$(BOLD)Populating database of local dimail API container$(RESET)"

--- a/docs/interoperability/dimail.md
+++ b/docs/interoperability/dimail.md
@@ -2,20 +2,45 @@
 
 ## What is dimail ? 
 
-The mailing solution provided in La Suite is [Open-XChange](https://www.open-xchange.com/) (OX). 
-OX not having a provisioning API, 'dimail-api' or 'dimail' was created to allow mail-provisioning through People.
+The mailing solution provided in La Suite is [La Messagerie](https://webmail.numerique.gouv.fr/), using [Open-XChange](https://www.open-xchange.com/) (OX). OX not having a provisioning API, 'dimail-api' or 'dimail' was created to allow mail-provisioning through People.
 
 API and its documentation can be found [here](https://api.dev.ox.numerique.gouv.fr/docs#/).
 
-## Architectural links of dimail
+## Use of dimail container
 
-As dimail's primary goal is to act as an interface between People and OX, its architecture is similar to that of People. A series of requests are sent from People to dimail upon creating domains, users, permissions and mailboxes.
+To ease local development, dimail provides a container that we embark in our docker-compose. In "FAKE" mode, it simulates all responses from Open Exchange.
+
+Bootstraping with command `make bootstrap` creates a container and initializes its database.
+
+Additional commands : 
+- Reset the database by recreating the container with `dimail-recreate-container`.
+- Populate the database with all the content of your People database with `dimail-setup-db`
+
+## Architecture
 
 ### Domains
 
 Upon creating a domain on People, the same domain is created on dimail and will undergo a series of checks. When all checks have passed, the domain is considered enabled. 
 
-Domains in OX have a field called "context". Context is a shared space between domains, allowing users to discover users not only on their domain but on their entire context.
+Domains in OX have a field called "context". "Contexts" are shared spaces between domains, allowing users to discover users not only on their domain but on their entire context.
+> [!NOTE]   
+> Contexts are only implemented in La Messagerie and are not currently in use in People. Domains created via People are in their own context.
+
+People users can have 3 levels of permissions on a domain:
+- Viewers can
+    - see the domain's information
+    - list its mailboxes and managers
+- Administrators can
+    - create mailboxes
+    - invite collaborators to manage domain
+    - change role of a viewer to administrators
+    - all of viewers permissions
+- Owners can
+    - promote administrators owners and demote owners
+    - all of viewers and administrators' permissions
+> [!NOTE]   
+> Contexts are only implemented in La Messagerie and are not currently in use in People. Domains created via People are in their own context.
+
 
 ### Mailboxes 
 
@@ -24,22 +49,3 @@ Mailboxes can be created by a domain owners or administrators in People's domain
 On enabled domains, mailboxes are created at the same time on dimail (and a confirmation email is sent to the secondary email).
 On pending/failed domains, mailboxes are only created locally with "pending" status and are sent to dimail upon domain's activation.
 On disabled domains, mailboxes creation is not allowed.
-
-### Users
-
-The ones issuing requests. Dimail users will reflect domains owners and administrators on People, for logging purposes and to allow direct use of dimail, if desired. User reconciliation is made on user uuid provided by ProConnect.
-
-### Permissions
-
-As for People, an access - a permissions (or an "allow" in dimail) - grants an user permission to create objects on a domain.
-
-Permissions requests are sent automatically upon : 
-- dimail database initialisation: 
-    + permission for dimail user People to create users and domains
-- domain creation : 
-    + permission for dimail user People to manage domain
-    + permission for new owner on new domain
-- user creation:
-    + permission for People to manage user
-- access creation, if owner or admin:
-    + permission for this user to manage domain

--- a/src/backend/mailbox_manager/api/client/serializers.py
+++ b/src/backend/mailbox_manager/api/client/serializers.py
@@ -235,29 +235,6 @@ class MailDomainAccessSerializer(serializers.ModelSerializer):
             )
         return attrs
 
-    def create(self, validated_data):
-        """
-        Override create function to fire requests to dimail on access creation.
-        """
-        dimail = DimailAPIClient()
-
-        user = validated_data["user"]
-        domain = validated_data["domain"]
-
-        if validated_data["role"] in [
-            enums.MailDomainRoleChoices.ADMIN,
-            enums.MailDomainRoleChoices.OWNER,
-        ]:
-            try:
-                dimail.create_user(user.sub)
-                dimail.create_allow(user.sub, domain.name)
-            except HTTPError:
-                logger.exception("[DIMAIL] access creation failed %s")
-                domain.status = enums.MailDomainStatusChoices.FAILED
-                domain.save()
-
-        return super().create(validated_data)
-
 
 class MailDomainAccessReadOnlySerializer(MailDomainAccessSerializer):
     """Serialize mail domain access for list and retrieve actions."""

--- a/src/backend/mailbox_manager/tests/api/mail_domain_accesses/test_api_mail_domain_accesses_create.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain_accesses/test_api_mail_domain_accesses_create.py
@@ -2,12 +2,9 @@
 Test for mail domain accesses API endpoints in People's core app : create
 """
 
-import logging
 import random
-import re
 
 import pytest
-import responses
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -108,16 +105,15 @@ def test_api_mail_domain__accesses_create_authenticated_administrator():
     client = APIClient()
     client.force_login(authenticated_user)
 
-    with responses.RequestsMock() as rsps:
-        # It should not be allowed to create an owner access
-        response = client.post(
-            f"/api/v1.0/mail-domains/{mail_domain.slug}/accesses/",
-            {
-                "user": str(other_user.id),
-                "role": enums.MailDomainRoleChoices.OWNER,
-            },
-            format="json",
-        )
+    # It should not be allowed to create an owner access
+    response = client.post(
+        f"/api/v1.0/mail-domains/{mail_domain.slug}/accesses/",
+        {
+            "user": str(other_user.id),
+            "role": enums.MailDomainRoleChoices.OWNER,
+        },
+        format="json",
+    )
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.json() == {
@@ -127,38 +123,14 @@ def test_api_mail_domain__accesses_create_authenticated_administrator():
     # It should be allowed to create a lower access
     for role in [enums.MailDomainRoleChoices.ADMIN, enums.MailDomainRoleChoices.VIEWER]:
         other_user = core_factories.UserFactory()
-        with responses.RequestsMock() as rsps:
-            if role != enums.MailDomainRoleChoices.VIEWER:
-                # viewers don't have allows in dimail
-                rsps.add(
-                    rsps.POST,
-                    re.compile(r".*/users/"),
-                    body=str(
-                        {
-                            "name": str(other_user.sub),
-                            "is_admin": "false",
-                            "uuid": "71f60d74-a3ad-46bc-bc2b-20d79a2e36fb",
-                            "perms": [],
-                        }
-                    ),
-                    status=status.HTTP_201_CREATED,
-                    content_type="application/json",
-                )
-                rsps.add(
-                    rsps.POST,
-                    re.compile(r".*/allows/"),
-                    body=str({"user": other_user.sub, "domain": str(mail_domain.name)}),
-                    status=status.HTTP_201_CREATED,
-                    content_type="application/json",
-                )
-            response = client.post(
-                f"/api/v1.0/mail-domains/{mail_domain.slug}/accesses/",
-                {
-                    "user": str(other_user.id),
-                    "role": role,
-                },
-                format="json",
-            )
+        response = client.post(
+            f"/api/v1.0/mail-domains/{mail_domain.slug}/accesses/",
+            {
+                "user": str(other_user.id),
+                "role": role,
+            },
+            format="json",
+        )
         assert response.status_code == status.HTTP_201_CREATED
         new_mail_domain_access = models.MailDomainAccess.objects.filter(
             user=other_user
@@ -182,37 +154,15 @@ def test_api_mail_domain__accesses_create_authenticated_owner():
 
     client = APIClient()
     client.force_login(authenticated_user)
-    with responses.RequestsMock() as rsps:
-        if role != enums.MailDomainRoleChoices.VIEWER:
-            rsps.add(
-                rsps.POST,
-                re.compile(r".*/users/"),
-                body=str(
-                    {
-                        "name": str(other_user.sub),
-                        "is_admin": "false",
-                        "uuid": "71f60d74-a3ad-46bc-bc2b-20d79a2e36fb",
-                        "perms": [],
-                    }
-                ),
-                status=status.HTTP_201_CREATED,
-                content_type="application/json",
-            )
-            rsps.add(
-                rsps.POST,
-                re.compile(r".*/allows/"),
-                body=str({"user": other_user.sub, "domain": str(mail_domain.name)}),
-                status=status.HTTP_201_CREATED,
-                content_type="application/json",
-            )
-        response = client.post(
-            f"/api/v1.0/mail-domains/{mail_domain.slug}/accesses/",
-            {
-                "user": str(other_user.id),
-                "role": role,
-            },
-            format="json",
-        )
+
+    response = client.post(
+        f"/api/v1.0/mail-domains/{mail_domain.slug}/accesses/",
+        {
+            "user": str(other_user.id),
+            "role": role,
+        },
+        format="json",
+    )
 
     assert response.status_code == status.HTTP_201_CREATED
     assert models.MailDomainAccess.objects.filter(user=other_user).count() == 1
@@ -221,146 +171,3 @@ def test_api_mail_domain__accesses_create_authenticated_owner():
     ).get()
     assert response.json()["id"] == str(new_mail_domain_access.id)
     assert response.json()["role"] == role
-
-
-## INTEROP WITH DIMAIL
-def test_api_mail_domains_accesses__create_dimail_allows(caplog):
-    """
-    Creating a domain access on our API should trigger a request to create an access on dimail too.
-    """
-    caplog.set_level(logging.INFO)
-
-    authenticated_user = core_factories.UserFactory()
-    domain = factories.MailDomainFactory(status="enabled")
-    factories.MailDomainAccessFactory(
-        domain=domain, user=authenticated_user, role=enums.MailDomainRoleChoices.OWNER
-    )
-    client = APIClient()
-    client.force_login(authenticated_user)
-
-    allowed_user = core_factories.UserFactory()
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            rsps.POST,
-            re.compile(r".*/users/"),
-            body=str(
-                {
-                    "name": str(allowed_user.sub),
-                    "is_admin": "false",
-                    "uuid": "71f60d74-a3ad-46bc-bc2b-20d79a2e36fb",
-                    "perms": [],
-                }
-            ),
-            status=status.HTTP_201_CREATED,
-            content_type="application/json",
-        )
-        rsps.add(
-            rsps.POST,
-            re.compile(r".*/allows/"),
-            body=str({"user": allowed_user.sub, "domain": str(domain.name)}),
-            status=status.HTTP_201_CREATED,
-            content_type="application/json",
-        )
-        response = client.post(
-            f"/api/v1.0/mail-domains/{domain.slug}/accesses/",
-            {
-                "user": str(allowed_user.id),
-                "role": enums.MailDomainRoleChoices.ADMIN,
-            },
-            format="json",
-        )
-
-    assert response.status_code == status.HTTP_201_CREATED
-
-    log_messages = [msg.message for msg in caplog.records]
-    # check logs
-    assert (
-        f'[DIMAIL] User "{allowed_user.sub}" successfully created on dimail'
-        in log_messages
-    )
-    assert (
-        f'[DIMAIL] Permissions granted for user "{allowed_user.sub}" on domain {domain.name}.'
-        in log_messages
-    )
-
-
-def test_api_mail_domains_accesses__dont_create_dimail_allows_for_viewer():
-    """Dimail should not be called when creating an access to a simple viewer."""
-
-    authenticated_user = core_factories.UserFactory()
-    domain = factories.MailDomainFactory(status="enabled")
-    factories.MailDomainAccessFactory(
-        domain=domain, user=authenticated_user, role=enums.MailDomainRoleChoices.OWNER
-    )
-    client = APIClient()
-    client.force_login(authenticated_user)
-
-    allowed_user = core_factories.UserFactory()
-    with responses.RequestsMock():
-        # No call expected
-        response = client.post(
-            f"/api/v1.0/mail-domains/{domain.slug}/accesses/",
-            {
-                "user": str(allowed_user.id),
-                "role": enums.MailDomainRoleChoices.VIEWER,
-            },
-            format="json",
-        )
-
-    assert response.status_code == status.HTTP_201_CREATED
-
-
-def test_api_mail_domains_accesses__user_already_on_dimail(caplog):
-    """The expected allow should be created when an user already exists on dimail
-    (i.e. previous admin/owner of same domain or current on another domain)."""
-    caplog.set_level(logging.INFO)
-
-    authenticated_user = core_factories.UserFactory()
-    domain = factories.MailDomainFactory()
-    factories.MailDomainAccessFactory(
-        domain=domain, user=authenticated_user, role=enums.MailDomainRoleChoices.OWNER
-    )
-    client = APIClient()
-    client.force_login(authenticated_user)
-
-    allowed_user = core_factories.UserFactory()
-
-    with responses.RequestsMock() as rsps:
-        # No call expected
-        rsps.add(
-            rsps.POST,
-            re.compile(r".*/users/"),
-            body=str(
-                {"detail": "User already exists"}
-            ),  # the user is already on dimail
-            status=status.HTTP_409_CONFLICT,
-            content_type="application/json",
-        )
-        rsps.add(
-            rsps.POST,
-            re.compile(r".*/allows/"),
-            body=str({"user": allowed_user.sub, "domain": str(domain.name)}),
-            status=status.HTTP_201_CREATED,
-            content_type="application/json",
-        )
-        response = client.post(
-            f"/api/v1.0/mail-domains/{domain.slug}/accesses/",
-            {
-                "user": str(allowed_user.id),
-                "role": enums.MailDomainRoleChoices.ADMIN,
-            },
-            format="json",
-        )
-
-    assert response.status_code == status.HTTP_201_CREATED
-
-    # check logs
-    log_messages = [msg.message for msg in caplog.records]
-    assert (
-        f'[DIMAIL] Attempt to create user "{allowed_user.sub}" which already exists.'
-        in log_messages
-    )
-    assert (
-        f'[DIMAIL] Permissions granted for user "{allowed_user.sub}" on domain {domain.name}.'
-        in log_messages
-    )

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_create.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_create.py
@@ -765,8 +765,7 @@ def test_api_mailboxes__handling_dimail_unexpected_error(caplog):
 @mock.patch.object(Logger, "info")
 def test_api_mailboxes__send_correct_logger_infos(mock_info, mock_error):
     """
-    Upon requesting mailbox creation, la régie should impersonate
-    querying user in dimail and log things correctly.
+    Upon requesting mailbox creation, logs should report request user.
     """
     access = factories.MailDomainAccessFactory(role=enums.MailDomainRoleChoices.OWNER)
 
@@ -801,9 +800,6 @@ def test_api_mailboxes__send_correct_logger_infos(mock_info, mock_error):
             format="json",
         )
         assert response.status_code == status.HTTP_201_CREATED
-
-        # user sub is sent to payload as a parameter
-        assert rsps.calls[0].request.params == {"username": access.user.sub}
 
     # Logger
     assert not mock_error.called


### PR DESCRIPTION
# Purpose

In this PR, we change the way people interact with dimail. We stop duplicating our users+permissions info to dimail. People with stop impersonating users in dimail and will create mailboxes using its own credentials (domain creation was already on its own credentials, nothing changes here).

We didn't remove `create_user` and `create_allows` methods in dimail client, because we need them to setup dimail database on local environments.

## Proposal

Description...

- [x] remove mock responses of /users and /allows on multiple domain-related tests
- [x] remove additional calls upon maildomain access creation and related tests
- [x] remove additional calls upon domain invitation consumption
- [x] update doc
