### PR TITLE
✨(mailbox) synchronize password of newly created mailbox with Dimail's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Changed
 
+- ✨(mailbox) synchronize password of newly created mailbox with Dimail's
 - ✨(mailbox) remove secondary email as required field
 
 ## [1.15.0] - 2025-04-04

--- a/src/backend/mailbox_manager/api/client/serializers.py
+++ b/src/backend/mailbox_manager/api/client/serializers.py
@@ -39,8 +39,7 @@ class MailboxSerializer(serializers.ModelSerializer):
         By default, we generate an unusable password for the mailbox, meaning that the mailbox
         will not be able to be used as a login credential until the password is set.
         """
-        mailbox = super().create(
-            validated_data
+        mailbox = super().create(validated_data
             | {
                 "password": make_password(None),  # generate an unusable password
             }
@@ -51,6 +50,8 @@ class MailboxSerializer(serializers.ModelSerializer):
             response = client.create_mailbox(mailbox, self.context["request"].user.sub)
 
             mailbox.status = enums.MailDomainStatusChoices.ENABLED
+            mailbox_data = response.json()
+            mailbox.set_password(mailbox_data["password"])
             mailbox.save()
 
             if mailbox.secondary_email:


### PR DESCRIPTION
## Purpose

When using La Régie as Identity Provider this allows signing in.

## Proposal

As a temporary measure, set the mailbox password to be the one created by Dimail. (Note that this raises further questions, such as what means we can provide for the user to set a different password.)