### PR TITLE
🔧(sentry) add Celery beat task integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- 🔧(sentry) add Celery beat task integration #892
+
 ### Changed
 
 - 🛂(dimail) simplify interop with dimail

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -21,6 +21,7 @@ import sentry_sdk
 from configurations import Configuration, values
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import ignore_logger
 
@@ -749,7 +750,10 @@ class Base(Configuration):
                 dsn=cls.SENTRY_DSN,
                 environment=cls.__name__.lower(),
                 release=get_release(),
-                integrations=[DjangoIntegration()],
+                integrations=[
+                    DjangoIntegration(),
+                    CeleryIntegration(monitor_beat_tasks=True),
+                ],
                 traces_sample_rate=0.1,
             )
 


### PR DESCRIPTION
## Purpose

This should provide "cron" monitoring in Sentry.
See https://sentry.incubateur.net/organizations/betagouv/crons/

## Proposal

- [x] add Celery beat task integration

## Validation

- [ ] check if celery beat tasks are present on  https://sentry.incubateur.net/organizations/betagouv/crons/
