### PR TITLE
✨(resource-server) add SCIM `/Me` endpoint

### DIFF
--- a/src/backend/core/api/resource_server/scim/__init__.py
+++ b/src/backend/core/api/resource_server/scim/__init__.py
@@ -1,0 +1,1 @@
+"""SCIM compliant API for resource server"""

--- a/src/backend/core/api/resource_server/scim/exceptions.py
+++ b/src/backend/core/api/resource_server/scim/exceptions.py
@@ -1,0 +1,16 @@
+"""Exceptions for SCIM API."""
+
+from django.conf import settings
+
+from core.api.resource_server.scim.response import ScimJsonResponse
+
+
+def scim_exception_handler(exc, _context):
+    """Handle SCIM exceptions and return them in the correct format."""
+    data = {
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        "status": str(exc.status_code),
+        "detail": str(exc.detail) if settings.DEBUG else "",
+    }
+
+    return ScimJsonResponse(data, status=exc.status_code)

--- a/src/backend/core/api/resource_server/scim/response.py
+++ b/src/backend/core/api/resource_server/scim/response.py
@@ -1,0 +1,16 @@
+"""SCIM API response classes."""
+
+from rest_framework.response import Response
+
+
+class ScimJsonResponse(Response):
+    """
+    Custom JSON response class for SCIM API.
+
+    This class sets the content type to "application/json+scim" for SCIM
+    responses.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """JSON response with enforced SCIM content type."""
+        super().__init__(*args, content_type="application/json+scim", **kwargs)

--- a/src/backend/core/api/resource_server/scim/serializers.py
+++ b/src/backend/core/api/resource_server/scim/serializers.py
@@ -1,0 +1,90 @@
+"""SCIM serializers for resource server API."""
+
+from django.urls import reverse
+
+from rest_framework import serializers
+
+from core import models
+
+
+class SCIMUserSerializer(serializers.ModelSerializer):
+    """Serialize users in SCIM format."""
+
+    schemas = serializers.SerializerMethodField()
+    userName = serializers.CharField(source="sub")
+    displayName = serializers.CharField(source="name")
+    emails = serializers.SerializerMethodField()
+    meta = serializers.SerializerMethodField()
+    groups = serializers.SerializerMethodField()
+    active = serializers.BooleanField(source="is_active")
+
+    class Meta:
+        model = models.User
+        fields = [
+            "id",
+            "schemas",
+            "active",
+            "userName",
+            "displayName",
+            "emails",
+            "groups",
+            "meta",
+        ]
+        read_only_fields = [
+            "id",
+            "schemas",
+            "active",
+            "userName",
+            "displayName",
+            "emails",
+            "groups",
+            "meta",
+        ]
+
+    def get_schemas(self, _obj):
+        """Return the SCIM schemas for the user."""
+        return ["urn:ietf:params:scim:schemas:core:2.0:User"]
+
+    def get_emails(self, obj):
+        """Return the user's email as a list of email objects."""
+        if obj.email:
+            return [
+                {
+                    "value": obj.email,
+                    "primary": True,
+                    "type": "work",
+                }
+            ]
+        return []
+
+    def get_groups(self, obj):
+        """
+        Return the groups the user belongs to.
+
+        WARNING: you need to prefetch the team accesses in the
+        viewset to avoid N+1 queries.
+        """
+        return [
+            {
+                "value": str(team_access.team.pk),
+                "display": team_access.team.name,
+                "type": "direct",
+            }
+            for team_access in obj.accesses.all()
+        ]
+
+    def get_meta(self, obj):
+        """Return metadata about the user."""
+        request = self.context.get("request")
+        location = (
+            f"{request.build_absolute_uri('/').rstrip('/')}{reverse('scim-me-list')}"
+            if request
+            else None
+        )
+
+        return {
+            "resourceType": "User",
+            "created": obj.created_at.isoformat(),
+            "lastModified": obj.updated_at.isoformat(),
+            "location": location,
+        }

--- a/src/backend/core/api/resource_server/scim/viewsets.py
+++ b/src/backend/core/api/resource_server/scim/viewsets.py
@@ -1,0 +1,62 @@
+"""Resource server SCIM API endpoints"""
+
+from django.contrib.auth import get_user_model
+from django.db.models import Prefetch, Q
+
+from lasuite.oidc_resource_server.mixins import ResourceServerMixin
+from rest_framework import (
+    viewsets,
+)
+
+from core.api import permissions
+from core.models import TeamAccess
+
+from . import serializers
+from .exceptions import scim_exception_handler
+from .response import ScimJsonResponse
+
+User = get_user_model()
+
+
+class MeViewSet(ResourceServerMixin, viewsets.ViewSet):
+    """
+    SCIM-compliant ViewSet for the /Me endpoint.
+
+    This endpoint provides information about the currently authenticated user
+    in SCIM (System for Cross-domain Identity Management) format.
+
+    Features:
+    - Returns user details in SCIM format.
+    - Includes the user's teams, restricted to the audience.
+
+    Limitations:
+    - Does not currently support managing Team hierarchies.
+
+    Endpoint:
+    GET /resource-server/v1.0/scim/Me/
+        Retrieves the authenticated user's details and associated teams.
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+    serializer_class = serializers.SCIMUserSerializer
+
+    def get_exception_handler(self):
+        """Override the default exception handler to use SCIM-specific handling."""
+        return scim_exception_handler
+
+    def list(self, request, *args, **kwargs):
+        """Return the current user's details in SCIM format."""
+        service_provider_audience = self._get_service_provider_audience()
+
+        user = User.objects.prefetch_related(
+            Prefetch(
+                "accesses",
+                queryset=TeamAccess.objects.select_related("team").filter(
+                    Q(team__service_providers__audience_id=service_provider_audience)
+                    | Q(team__is_visible_all_services=True)
+                ),
+            )
+        ).get(pk=request.user.pk)
+
+        serializer = self.serializer_class(user, context={"request": request})
+        return ScimJsonResponse(serializer.data)

--- a/src/backend/core/tests/resource_server_api/scim/__init__.py
+++ b/src/backend/core/tests/resource_server_api/scim/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the resource server SCIM API endpoints."""

--- a/src/backend/core/tests/resource_server_api/scim/test_me.py
+++ b/src/backend/core/tests/resource_server_api/scim/test_me.py
@@ -1,0 +1,186 @@
+"""
+Tests for the SCIM Me API endpoint in People's core app
+"""
+
+import pytest
+from rest_framework.status import (
+    HTTP_200_OK,
+    HTTP_401_UNAUTHORIZED,
+    HTTP_405_METHOD_NOT_ALLOWED,
+)
+
+from core import factories
+from core.models import RoleChoices
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_me_anonymous(client):
+    """Anonymous users should not be allowed to access the Me endpoint."""
+    response = client.get("/resource-server/v1.0/scim/Me/")
+
+    assert response.status_code == HTTP_401_UNAUTHORIZED
+    assert response.headers["Content-Type"] == "application/json+scim"
+
+    # Check the full response with the expected structure
+    assert response.json() == {
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        "status": "401",
+        "detail": "",
+    }
+
+
+def test_api_me_authenticated(
+    client, force_login_via_resource_server, django_assert_num_queries
+):
+    """
+    Authenticated users should be able to access their own information
+    in SCIM format.
+    """
+    user = factories.UserFactory(name="Test User", email="test@example.com")
+    service_provider = factories.ServiceProviderFactory()
+
+    # Authenticate using the resource server, ie via the Authorization header
+    with force_login_via_resource_server(client, user, service_provider.audience_id):
+        with django_assert_num_queries(2):
+            response = client.get(
+                "/resource-server/v1.0/scim/Me/",
+                format="json",
+                HTTP_AUTHORIZATION="Bearer b64untestedbearertoken",
+            )
+
+    assert response.status_code == HTTP_200_OK
+    assert response.headers["Content-Type"] == "application/json+scim"
+
+    # Check the full response with the expected structure
+    assert response.json() == {
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "id": str(user.pk),
+        "active": True,
+        "userName": user.sub,
+        "displayName": user.name,
+        "emails": [
+            {
+                "value": user.email,
+                "primary": True,
+                "type": "work",
+            }
+        ],
+        "groups": [],
+        "meta": {
+            "resourceType": "User",
+            "created": user.created_at.isoformat(),
+            "lastModified": user.updated_at.isoformat(),
+            "location": "http://testserver/resource-server/v1.0/scim/Me/",
+        },
+    }
+
+
+def test_api_me_authenticated_with_team_access(
+    client, force_login_via_resource_server, django_assert_num_queries
+):
+    """
+    Authenticated users with TeamAccess should see their team information
+    in SCIM format, but only for teams visible to the service provider.
+    """
+    user = factories.UserFactory(name="Test User", email="test@example.com")
+    service_provider = factories.ServiceProviderFactory()
+
+    # Create teams with different visibility settings
+    team_visible = factories.TeamFactory(name="Visible Team")
+    team_visible.service_providers.add(service_provider)
+
+    team_all_services = factories.TeamFactory(
+        name="All Services Team", is_visible_all_services=True
+    )
+
+    team_not_visible = factories.TeamFactory(name="Not Visible Team")
+    # This team is not associated with the service provider
+
+    # Add user to all teams
+    factories.TeamAccessFactory(user=user, team=team_visible, role=RoleChoices.MEMBER)
+    factories.TeamAccessFactory(
+        user=user, team=team_all_services, role=RoleChoices.ADMIN
+    )
+    factories.TeamAccessFactory(
+        user=user, team=team_not_visible, role=RoleChoices.OWNER
+    )
+
+    # Authenticate using the resource server, ie via the Authorization header
+    with force_login_via_resource_server(client, user, service_provider.audience_id):
+        with django_assert_num_queries(
+            2
+        ):  # User + TeamAccess (with select_related teams)
+            response = client.get(
+                "/resource-server/v1.0/scim/Me/",
+                format="json",
+                HTTP_AUTHORIZATION="Bearer b64untestedbearertoken",
+            )
+
+    assert response.status_code == HTTP_200_OK
+    assert response.headers["Content-Type"] == "application/json+scim"
+    # Check the full response with the expected structure
+    assert response.json() == {
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "id": str(user.pk),
+        "active": True,
+        "userName": user.sub,
+        "displayName": user.name,
+        "emails": [
+            {
+                "value": user.email,
+                "primary": True,
+                "type": "work",
+            }
+        ],
+        "groups": [
+            {
+                "value": str(team_visible.pk),
+                "display": team_visible.name,
+                "type": "direct",
+            },
+            {
+                "value": str(team_all_services.pk),
+                "display": team_all_services.name,
+                "type": "direct",
+            },
+        ],
+        "meta": {
+            "resourceType": "User",
+            "created": user.created_at.isoformat(),
+            "lastModified": user.updated_at.isoformat(),
+            "location": "http://testserver/resource-server/v1.0/scim/Me/",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "http_method",
+    ["post", "put", "patch", "delete"],
+    ids=["POST", "PUT", "PATCH", "DELETE"],
+)
+def test_api_me_method_not_allowed(
+    client, force_login_via_resource_server, http_method
+):
+    """Test that methods other than GET are not allowed for the Me endpoint."""
+    user = factories.UserFactory()
+    service_provider = factories.ServiceProviderFactory()
+
+    # Authenticate using the resource server, ie via the Authorization header
+    with force_login_via_resource_server(client, user, service_provider.audience_id):
+        client_method = getattr(client, http_method)
+        response = client_method(
+            "/resource-server/v1.0/scim/Me/",
+            format="json",
+            HTTP_AUTHORIZATION="Bearer b64untestedbearertoken",
+        )
+
+    assert response.status_code == HTTP_405_METHOD_NOT_ALLOWED
+    assert response.headers["Content-Type"] == "application/json+scim"
+
+    # Check the full response with the expected structure
+    assert response.json() == {
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        "status": str(HTTP_405_METHOD_NOT_ALLOWED),
+        "detail": "",
+    }

--- a/src/backend/people/resource_server_urls.py
+++ b/src/backend/people/resource_server_urls.py
@@ -3,18 +3,23 @@
 from django.urls import include, path
 
 from lasuite.oidc_resource_server.urls import urlpatterns as resource_server_urls
-from rest_framework.routers import DefaultRouter
+from rest_framework.routers import SimpleRouter
 
 from core.api.resource_server import viewsets
+from core.api.resource_server.scim import viewsets as scim_viewsets
 
 # - Main endpoints
 # Contacts will be added later
 # Users will be added later
-router = DefaultRouter()
+router = SimpleRouter()
 router.register("teams", viewsets.TeamViewSet, basename="teams")
 
+# - SCIM endpoints
+scim_router = SimpleRouter()
+scim_router.register("Me", scim_viewsets.MeViewSet, basename="scim-me")
+
 # - Routes nested under a team
-team_related_router = DefaultRouter()
+team_related_router = SimpleRouter()
 team_related_router.register(
     "invitations",
     viewsets.InvitationViewset,
@@ -33,6 +38,7 @@ urlpatterns = [
                 *router.urls,
                 *resource_server_urls,
                 path("teams/<uuid:team_id>/", include(team_related_router.urls)),
+                path("scim/", include(scim_router.urls)),
             ]
         ),
     ),


### PR DESCRIPTION
## Purpose

This provides a "self-care" SCIM endpoint, authenticated with OIDC token introspection. This endpoint will be use by services to fetch the user's team list.

We chose to use the SCIM format (even if this is not a SCIM context) to make it easier to understand/maintain/plug.

## Proposal

Add a new resource server authenticated SCIM formatted endpoint: `/Me`

- [x] add `/Me` endpoint
- [x] add tests for response format content
