### PR TITLE
🔒️(drf) disable browsable HTML API renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🔒️(drf) disable browsable HTML API renderer #897
+
 ### Added
 
 - 🔧(sentry) add Celery beat task integration #892

--- a/src/backend/mailbox_oauth2/tests/test_views.py
+++ b/src/backend/mailbox_oauth2/tests/test_views.py
@@ -20,9 +20,9 @@ def test_login_view_options(client):
     assert response.status_code == 200
     assert response.headers == {
         "Content-Type": "application/json",
-        "Vary": "Accept, Authorization, origin, Accept-Language, Cookie",
+        "Vary": "Authorization, origin, Accept-Language, Cookie",
         "Allow": "POST, OPTIONS",
-        "Content-Length": "209",
+        "Content-Length": "197",
         "X-Frame-Options": "DENY",
         "Content-Language": "en-us",
         "X-Content-Type-Options": "nosniff",
@@ -52,7 +52,7 @@ def test_login_view_authorize(client):
 
     assert response.headers == {
         "Content-Type": "application/json",
-        "Vary": "Accept, Authorization, Cookie, origin, Accept-Language",
+        "Vary": "Authorization, Cookie, origin, Accept-Language",
         "Allow": "POST, OPTIONS",
         "Content-Length": "36",
         "X-Frame-Options": "DENY",

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -276,6 +276,12 @@ class Base(Configuration):
             "nested_multipart_parser.drf.DrfNestedParser",
         ],
         "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
+        "DEFAULT_RENDERER_CLASSES": [
+            # 🔒️ Disable BrowsableAPIRenderer which provides forms allowing a user to
+            # see all the data in the database (ie a serializer with a ForeignKey field
+            # will generate a form with a field with all possible values of the FK).
+            "rest_framework.renderers.JSONRenderer",
+        ],
         "EXCEPTION_HANDLER": "core.api.exception_handler",
         "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
         "PAGE_SIZE": 20,


### PR DESCRIPTION
## Purpose

The `BrowsableAPIRenderer` generates a form to test POST/PUT/... actions and fill the FK fields with unfiltered data. 


https://github.com/user-attachments/assets/da8f7e52-cd26-403d-8d68-08a87b7e43ca



## Proposal

This issue has been spoted on visio and fixed https://github.com/suitenumerique/meet/pull/508
