### PR TITLE
✨(frontend) add button to reset password

### DIFF
--- a/src/backend/mailbox_manager/api/client/viewsets.py
+++ b/src/backend/mailbox_manager/api/client/viewsets.py
@@ -249,6 +249,9 @@ class MailBoxViewSet(
 
     POST /api/<version>/mail-domains/<domain_slug>/mailboxes/<mailbox_id>/enable/
         Send a request to dimail to enable mailbox and change status of the mailbox in our DB
+
+    POST /api/<version>/mail-domains/<domain_slug>/mailboxes/<mailbox_id>/reset/
+        Send a request to mail-provider to reset password.
     """
 
     permission_classes = [permissions.MailBoxPermission]

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_create.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_create.py
@@ -550,7 +550,7 @@ def test_api_mailboxes__domain_owner_or_admin_successful_creation_and_provisioni
     """
     Domain owner/admin should be able to create mailboxes.
     Provisioning API should be called when owner/admin makes a call.
-    Succesfull 201 response from dimail should trigger mailbox creation on our side.
+    successful 201 response from dimail should trigger mailbox creation on our side.
     """
     # creating all needed objects
     access = factories.MailDomainAccessFactory(role=role)
@@ -805,7 +805,7 @@ def test_api_mailboxes__send_correct_logger_infos(mock_info, mock_error):
     assert not mock_error.called
     # Check all expected log messages are present, order doesn't matter
     expected_messages = {
-        ("Token succesfully granted by mail-provisioning API.",),
+        ("Token successfully granted by mail-provisioning API.",),
         (
             "Mailbox successfully created on domain %s by user %s",
             str(access.domain),

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_reset_password.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_reset_password.py
@@ -125,6 +125,12 @@ def test_api_mailboxes__reset_password_admin_successful(role):
     dimail_url = settings.MAIL_PROVISIONING_API_URL
 
     responses.add(
+        responses.GET,
+        f"{dimail_url}/token/",
+        body=dimail.TOKEN_OK,
+        status=200,
+    )
+    responses.add(
         responses.POST,
         f"{dimail_url}/domains/{mail_domain.name}/mailboxes/{mailbox.local_part}/reset_password/",
         body=dimail.response_mailbox_created(str(mailbox)),
@@ -169,6 +175,12 @@ def test_api_mailboxes__reset_password_connexion_failed():
     client.force_login(access.user)
 
     dimail_url = settings.MAIL_PROVISIONING_API_URL
+    responses.add(
+        responses.GET,
+        f"{dimail_url}/token/",
+        body=dimail.TOKEN_OK,
+        status=200,
+    )
     responses.add(
         responses.POST,
         f"{dimail_url}/domains/{mail_domain.name}/mailboxes/{mailbox.local_part}/reset_password/",

--- a/src/backend/mailbox_manager/tests/fixtures/dimail.py
+++ b/src/backend/mailbox_manager/tests/fixtures/dimail.py
@@ -7,7 +7,7 @@ import json
 
 
 def response_user_created(user_sub):
-    """mimic dimail response upon succesfull user creation."""
+    """mimic dimail response upon successful user creation."""
     return json.dumps(
         {
             "name": user_sub,
@@ -297,7 +297,7 @@ TOKEN_OK = json.dumps({"access_token": "token", "token_type": "bearer"})
 
 
 def response_allows_created(user_name, domain_name):
-    """mimic dimail response upon succesfull allows creation.
+    """mimic dimail response upon successful allows creation.
     Dimail expects a name but our names are ProConnect's uuids."""
     return json.dumps({"user": user_name, "domain": domain_name})
 
@@ -306,5 +306,5 @@ def response_allows_created(user_name, domain_name):
 
 
 def response_mailbox_created(email_address):
-    """mimic dimail response upon succesfull mailbox creation."""
+    """mimic dimail response upon successful mailbox creation."""
     return json.dumps({"email": email_address, "password": "password"})

--- a/src/backend/mailbox_manager/tests/test_utils_dimail_client.py
+++ b/src/backend/mailbox_manager/tests/test_utils_dimail_client.py
@@ -388,7 +388,7 @@ def test_dimail__send_pending_mailboxes(caplog):
     assert mailbox2.status == enums.MailboxStatusChoices.ENABLED
 
     log_messages = [msg.message for msg in caplog.records]
-    assert "Token succesfully granted by mail-provisioning API." in log_messages
+    assert "Token successfully granted by mail-provisioning API." in log_messages
     assert (
         f"Mailbox successfully created on domain {domain.name} by user None"
         in log_messages

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -616,7 +616,7 @@ class DimailAPIClient:
         try:
             response = session.post(
                 f"{self.API_URL}/domains/{mailbox.domain.name}/mailboxes/{mailbox.local_part}/reset_password/",
-                headers={"Authorization": f"Basic {self.API_CREDENTIALS}"},
+                headers=self.get_headers(),
                 verify=True,
                 timeout=self.API_TIMEOUT,
             )

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -71,7 +71,7 @@ class DimailAPIClient:
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {response.json()['access_token']}",
             }
-            logger.info("Token succesfully granted by mail-provisioning API.")
+            logger.info("Token successfully granted by mail-provisioning API.")
             return headers
 
         if response.status_code == status.HTTP_403_FORBIDDEN:

--- a/src/frontend/apps/desk/src/features/mail-domains/mailboxes/api/useUpdateMailboxStatus.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/mailboxes/api/useUpdateMailboxStatus.tsx
@@ -10,6 +10,45 @@ export interface DisableMailboxParams {
   isEnabled: boolean;
 }
 
+export interface ResetPasswordParams {
+  mailDomainSlug: string;
+  mailboxId: string;
+}
+
+export const resetPassword = async ({
+  mailDomainSlug,
+  mailboxId,
+}: ResetPasswordParams): Promise<void> => {
+  const response = await fetchAPI(
+    `mail-domains/${mailDomainSlug}/mailboxes/${mailboxId}/reset_password/`,
+    {
+      method: 'POST',
+    },
+  );
+
+  if (!response.ok) {
+    throw new APIError(
+      'Failed to reset mailbox password',
+      await errorCauses(response),
+    );
+  }
+};
+
+export const useResetPassword = () => {
+  const queryClient = useQueryClient();
+  return useMutation<void, APIError, ResetPasswordParams>({
+    mutationFn: resetPassword,
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: [
+          KEY_LIST_MAILBOX,
+          { mailDomainSlug: variables.mailDomainSlug },
+        ],
+      });
+    },
+  });
+};
+
 export const disableMailbox = async ({
   mailDomainSlug,
   mailboxId,

--- a/src/frontend/apps/desk/src/features/mail-domains/mailboxes/components/panel/PanelActions.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/mailboxes/components/panel/PanelActions.tsx
@@ -13,7 +13,10 @@ import { Box, DropButton, IconOptions, Text } from '@/components';
 import { MailDomain } from '@/features/mail-domains/domains';
 import { ViewMailbox } from '@/features/mail-domains/mailboxes';
 
-import { useUpdateMailboxStatus } from '../../api/useUpdateMailboxStatus';
+import {
+  useResetPassword,
+  useUpdateMailboxStatus,
+} from '../../api/useUpdateMailboxStatus';
 
 interface PanelActionsProps {
   mailbox: ViewMailbox;
@@ -28,6 +31,7 @@ export const PanelActions = ({ mailDomain, mailbox }: PanelActionsProps) => {
   const { toast } = useToastProvider();
 
   const { mutate: updateMailboxStatus } = useUpdateMailboxStatus();
+  const { mutate: resetPassword } = useResetPassword();
 
   const handleUpdateMailboxStatus = () => {
     disableModal.close();
@@ -40,6 +44,20 @@ export const PanelActions = ({ mailDomain, mailbox }: PanelActionsProps) => {
       {
         onError: () =>
           toast(t('Failed to update mailbox status'), VariantType.ERROR),
+      },
+    );
+  };
+
+  const handleResetMailboxPassword = () => {
+    resetPassword(
+      {
+        mailDomainSlug: mailDomain.slug,
+        mailboxId: mailbox.id,
+      },
+      {
+        onSuccess: () =>
+          toast(t('Successfully reset password.'), VariantType.SUCCESS),
+        onError: () => toast(t('Failed to reset password'), VariantType.ERROR),
       },
     );
   };
@@ -85,6 +103,24 @@ export const PanelActions = ({ mailDomain, mailbox }: PanelActionsProps) => {
           >
             <Text $theme="primary">
               {isEnabled ? t('Disable mailbox') : t('Enable mailbox')}
+            </Text>
+          </Button>
+          <Button
+            aria-label={t('Open the modal to update the role of this access')}
+            onClick={() => {
+              setIsDropOpen(false);
+              handleResetMailboxPassword();
+            }}
+            color="primary-text"
+            disabled={!isEnabled}
+            icon={
+              <span className="material-icons" aria-hidden="true">
+                {isEnabled ? 'lock_reset' : ' block'}
+              </span>
+            }
+          >
+            <Text $theme={isEnabled ? 'primary' : 'greyscale'}>
+              {isEnabled ? t('Reset password') : t('Reset password')}
             </Text>
           </Button>
         </Box>


### PR DESCRIPTION
## Purpose

Domain admins and owners can now send requests to reset password for any mailbox properly configured on domains they manage.

![image](https://github.com/user-attachments/assets/704c76c1-ce08-40ea-a359-4b0b95ed2500)
![image](https://github.com/user-attachments/assets/b13f63b6-b5a5-4c28-9547-0641cfa4bcfa)



I'm thinking about deactivating the "cannot reset password" button entirely when mailbox is disabled.

## Proposal

Description...

- [x] create button
- [x] UI v2 merged 👏🏽 
- [x] debug JSON-related error => Requesting the reset actually resets and sends a mail ! 
- [x] add confirmation toast 

![image](https://github.com/user-attachments/assets/b526dd08-8b25-47e4-9421-df02db692551)

Confirmation toasts
![image](https://github.com/user-attachments/assets/13d4a4f1-d8e8-43d5-a9a3-90fa54ea2d59)

## Improvements

- As discussed in review, we'll wait for feature to be more mature to write e2e tests
