### PR TITLE
🧑‍💻(frontend) add makefile `lint --fix`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,9 +158,13 @@ lint-pylint: ## lint back-end python sources with pylint only on changed files f
 	bin/pylint --diff-only=origin/main
 .PHONY: lint-pylint
 
-lint-front:
+lint-front: ## lint front-end sources with eslint
 	cd $(PATH_FRONT) && yarn lint
 .PHONY: lint-front
+
+lint-front-fix: ## fix front-end sources with eslint
+	cd $(PATH_FRONT) && yarn lint-fix
+.PHONY: lint-front-fix
 
 test: ## run project tests
 	@$(MAKE) test-back-parallel

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -19,6 +19,7 @@
     "ci:build": "yarn APP_DESK run build:ci",
     "e2e:test": "yarn APP_E2E run test",
     "lint": "yarn APP_DESK run lint && yarn APP_E2E run lint && yarn workspace eslint-config-people run lint && yarn I18N run lint",
+    "lint-fix": "yarn APP_DESK run lint --fix && yarn APP_E2E run lint --fix && yarn workspace eslint-config-people run lint --fix && yarn I18N run lint --fix",
     "i18n:extract": "yarn I18N run extract-translation",
     "i18n:deploy": "yarn I18N run format-deploy && yarn APP_DESK prettier",
     "i18n:test": "yarn I18N run test"


### PR DESCRIPTION
## Purpose

Some frontend lint can be fixed automatically, it should be easier for dev.


## Proposal

Add a Makefile command to easily run the automatic fixup for frontend files.
