### PR TITLE
🔒️(frontend) hide Nginx server version in error responses

### DIFF
--- a/src/frontend/apps/desk/conf/default.conf
+++ b/src/frontend/apps/desk/conf/default.conf
@@ -1,6 +1,7 @@
 server {
   listen 8080;
   server_name localhost;
+  server_tokens off;
 
   root /usr/share/nginx/html;
 


### PR DESCRIPTION
## Purpose

Remove version disclosure in /assets/ error pages identified by security auditor to prevent information leakage vulnerability.



## Proposal

- [x] update nginx configuration
