### PR TITLE
🐛(domains) improve logs around domain invitations

### DIFF
--- a/src/backend/mailbox_manager/signals.py
+++ b/src/backend/mailbox_manager/signals.py
@@ -23,7 +23,6 @@ def convert_domain_invitations(sender, created, instance, **kwargs):  # pylint: 
     Convert valid domain invitations to domain accesses for a given user.
     Expired invitations are ignored.
     """
-    logger.info("Convert domain invitations for user %s", instance)
     if created:
         valid_domain_invitations = MailDomainInvitation.objects.filter(
             email=instance.email,
@@ -36,6 +35,11 @@ def convert_domain_invitations(sender, created, instance, **kwargs):  # pylint: 
         if not valid_domain_invitations.exists():
             return
 
+        logger.info(
+            "Converting %s domain invitations for new user %s",
+            len(valid_domain_invitations),
+            instance,
+        )
         MailDomainAccess.objects.bulk_create(
             [
                 MailDomainAccess(
@@ -46,4 +50,3 @@ def convert_domain_invitations(sender, created, instance, **kwargs):  # pylint: 
         )
 
         valid_domain_invitations.delete()
-        logger.info("Invitations converted to domain accesses for user %s", instance)

--- a/src/backend/mailbox_manager/tests/models/test_invitations.py
+++ b/src/backend/mailbox_manager/tests/models/test_invitations.py
@@ -38,11 +38,15 @@ def test_models_domain_invitations__is_expired():
     assert expired_invitation.is_expired is True
 
 
-def test_models_domain_invitation__should_convert_invitations_to_accesses_upon_joining():
+def test_models_domain_invitation__should_convert_invitations_to_accesses_upon_joining(
+    caplog,
+):
     """
     Upon creating a new user, domain invitations linked to that email
     should be converted to accesses and then deleted.
     """
+    caplog.set_level("INFO")
+
     # Two invitations to the same mail but to different domains
     email = "future_admin@example.com"
     invitation_to_domain1 = factories.MailDomainInvitationFactory(
@@ -81,3 +85,8 @@ def test_models_domain_invitation__should_convert_invitations_to_accesses_upon_j
     assert models.MailDomainInvitation.objects.filter(
         domain=invitation_to_domain2.domain, email=other_invitation.email
     ).exists()  # the other invitation remains
+
+    log_messages = [msg.message for msg in caplog.records]
+    assert (
+        f"Converting 2 domain invitations for new user {str(new_user)}" in log_messages
+    )


### PR DESCRIPTION
## Purpose

reduce logs and add tests around domain invitations

## Proposal

Description...

- [x] move logger.info to log only when valid invitations
- [x] add log confirmation on tests
- [x] add test to check behavior when inviting already existing user 
