### PR TITLE
 🔧(git) set LF line endings for all text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Set the default behavior for all files
+* text=auto eol=lf
+
+# Binary files (should not be modified)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.flv binary
+*.fla binary
+*.swf binary
+*.gz binary
+*.zip binary
+*.7z binary
+*.ttf binary
+*.woff binary
+*.woff2 binary
+*.eot binary
+*.pdf binary
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - ✨(resource-server) add SCIM /Me endpoint #895
+- 🔧(git) set LF line endings for all text files #928
 
 ### Changed
 


### PR DESCRIPTION
## Purpose

Windows users are by default using CRLF line endings, which can cause issues with some tools and
environments. This commit sets the `.gitattributes` file to enforce LF line endings for all text
files in the repository.

Based on the same commit on docs : https://github.com/suitenumerique/docs/commit/fbb27990508fee7184a32675c226799c7a8a7b11

## Proposal

See above
