### PR TITLE
✨(api) update mailboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - ✨(api) update mailboxes #934
+- ✨(api) give update rights to domain viewer on own mailbox #934
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(api) update mailboxes #934
+
 ### Changed
 
 - 💥(sentry) remove `DJANGO_` before Sentry DSN env variable #957

--- a/src/backend/mailbox_manager/api/client/serializers.py
+++ b/src/backend/mailbox_manager/api/client/serializers.py
@@ -29,7 +29,6 @@ class MailboxSerializer(serializers.ModelSerializer):
             "secondary_email",
             "status",
         ]
-        # everything is actually read-only as we do not allow update for now
         read_only_fields = ["id", "status"]
 
     def create(self, validated_data):
@@ -69,6 +68,22 @@ class MailboxSerializer(serializers.ModelSerializer):
 
         # actually save mailbox on our database
         return mailbox
+
+
+class MailboxUpdateSerializer(MailboxSerializer):
+    """A more restrictive serializer when updating mailboxes"""
+
+    class Meta:
+        model = models.Mailbox
+        fields = [
+            "id",
+            "first_name",
+            "last_name",
+            "local_part",
+            "secondary_email",
+            "status",
+        ]
+        read_only_fields = ("id", "status", "local_part", "status")
 
 
 class MailDomainSerializer(serializers.ModelSerializer):

--- a/src/backend/mailbox_manager/api/client/serializers.py
+++ b/src/backend/mailbox_manager/api/client/serializers.py
@@ -83,7 +83,7 @@ class MailboxUpdateSerializer(MailboxSerializer):
             "secondary_email",
             "status",
         ]
-        read_only_fields = ("id", "status", "local_part", "status")
+        read_only_fields = ("id", "local_part", "status")
 
 
 class MailDomainSerializer(serializers.ModelSerializer):

--- a/src/backend/mailbox_manager/api/client/viewsets.py
+++ b/src/backend/mailbox_manager/api/client/viewsets.py
@@ -228,9 +228,10 @@ class MailDomainAccessViewSet(
 
 
 class MailBoxViewSet(
+    viewsets.GenericViewSet,
     mixins.CreateModelMixin,
     mixins.ListModelMixin,
-    viewsets.GenericViewSet,
+    mixins.UpdateModelMixin,
 ):
     """MailBox ViewSet
 
@@ -252,6 +253,12 @@ class MailBoxViewSet(
 
     POST /api/<version>/mail-domains/<domain_slug>/mailboxes/<mailbox_id>/reset/
         Send a request to mail-provider to reset password.
+
+    PUT /api/<version>/mail-domains/<domain_slug>/mailboxes/<mailbox_id>/
+        Send a request to update mailbox. Cannot modify domain or local_part.
+
+    PATCH /api/<version>/mail-domains/<domain_slug>/mailboxes/<mailbox_id>/
+        Send a request to partially update mailbox. Cannot modify domain or local_part.
     """
 
     permission_classes = [permissions.MailBoxPermission]
@@ -266,6 +273,12 @@ class MailBoxViewSet(
         if domain_slug:
             return self.queryset.filter(domain__slug=domain_slug)
         return self.queryset
+
+    def get_serializer_class(self):
+        """Chooses list or detail serializer according to the action."""
+        if self.action in {"update", "partial_update"}:
+            return serializers.MailboxUpdateSerializer
+        return self.serializer_class
 
     def perform_create(self, serializer):
         """Create new mailbox."""

--- a/src/backend/mailbox_manager/api/client/viewsets.py
+++ b/src/backend/mailbox_manager/api/client/viewsets.py
@@ -274,6 +274,17 @@ class MailBoxViewSet(
             return self.queryset.filter(domain__slug=domain_slug)
         return self.queryset
 
+    def get_permissions(self):
+        """Add a specific permission for domain viewers to update their own mailbox."""
+        if self.action in ["update", "partial_update"]:
+            permission_classes = [
+                permissions.MailBoxPermission | permissions.IsMailboxOwnerPermission
+            ]
+        else:
+            return super().get_permissions()
+
+        return [permission() for permission in permission_classes]
+
     def get_serializer_class(self):
         """Chooses list or detail serializer according to the action."""
         if self.action in {"update", "partial_update"}:

--- a/src/backend/mailbox_manager/api/client/viewsets.py
+++ b/src/backend/mailbox_manager/api/client/viewsets.py
@@ -232,6 +232,7 @@ class MailBoxViewSet(
     mixins.CreateModelMixin,
     mixins.ListModelMixin,
     mixins.UpdateModelMixin,
+    mixins.RetrieveModelMixin,
 ):
     """MailBox ViewSet
 

--- a/src/backend/mailbox_manager/api/permissions.py
+++ b/src/backend/mailbox_manager/api/permissions.py
@@ -1,5 +1,7 @@
 """Permission handlers for the People mailbox manager app."""
 
+from rest_framework import permissions
+
 from core.api import permissions as core_permissions
 
 from mailbox_manager import models
@@ -24,7 +26,7 @@ class MailBoxPermission(AccessPermission):
         return abilities.get(request.method.lower(), False)
 
 
-class IsMailboxOwnerPermission(core_permissions.IsAuthenticated):
+class IsMailboxOwnerPermission(permissions.BasePermission):
     """Authorize update for domain viewers on their own mailbox."""
 
     def has_permission(self, request, view):

--- a/src/backend/mailbox_manager/api/permissions.py
+++ b/src/backend/mailbox_manager/api/permissions.py
@@ -23,6 +23,11 @@ class MailBoxPermission(core_permissions.IsAuthenticated):
         abilities = domain.get_abilities(request.user)
         return abilities.get(request.method.lower(), False)
 
+    def has_object_permission(self, request, view, obj):
+        """Check permission for a given object."""
+        abilities = obj.get_abilities(request.user)
+        return abilities.get(request.method.lower(), False)
+
 
 class MailDomainAccessRolePermission(core_permissions.IsAuthenticated):
     """Permission class to manage mailboxes for a mail domain"""

--- a/src/backend/mailbox_manager/models.py
+++ b/src/backend/mailbox_manager/models.py
@@ -350,11 +350,13 @@ class Mailbox(AbstractBaseUser, BaseModel):
             MailDomainRoleChoices.ADMIN,
         ]
 
+        is_self = self.get_email() == user.email
+
         return {
             "get": bool(role),
             "post": is_owner_or_admin,
-            "patch": is_owner_or_admin,
-            "put": is_owner_or_admin,
+            "patch": is_owner_or_admin or is_self,
+            "put": is_owner_or_admin or is_self,
             "delete": False,
         }
 

--- a/src/backend/mailbox_manager/models.py
+++ b/src/backend/mailbox_manager/models.py
@@ -341,6 +341,23 @@ class Mailbox(AbstractBaseUser, BaseModel):
         """Return the email address of the mailbox."""
         return f"{self.local_part}@{self.domain.name}"
 
+    def get_abilities(self, user):
+        """Compute and return abilities for a given user."""
+        role = user.mail_domain_accesses.get(domain=self.domain).role
+
+        is_owner_or_admin = role in [
+            MailDomainRoleChoices.OWNER,
+            MailDomainRoleChoices.ADMIN,
+        ]
+
+        return {
+            "get": bool(role),
+            "post": is_owner_or_admin,
+            "patch": is_owner_or_admin,
+            "put": is_owner_or_admin,
+            "delete": False,
+        }
+
 
 class MailDomainInvitation(BaseInvitation):
     """User invitation to mail domains."""

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_patch.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_patch.py
@@ -1,0 +1,171 @@
+"""
+Unit tests for the mailbox API
+"""
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core import factories as core_factories
+
+from mailbox_manager import enums, factories
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_mailboxes_patch__anonymous_forbidden():
+    """Anonymous users should not be able to update a mailbox."""
+    mailbox = factories.MailboxFactory()
+    saved_secondary = mailbox.secondary_email
+    APIClient().get(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/"
+    )
+    response = APIClient().patch(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/",
+        {"something": "updated"},
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    mailbox.refresh_from_db()
+    assert mailbox.secondary_email == saved_secondary
+
+
+def test_api_mailboxes_patch__unauthorized_forbidden():
+    """Authenticated but unauthoriezd users should not be able to update mailboxes."""
+    client = APIClient()
+    client.force_login(core_factories.UserFactory())
+
+    mailbox = factories.MailboxFactory()
+    saved_secondary = mailbox.secondary_email
+    response = client.patch(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/",
+        {"something": "updated"},
+        format="json",
+    )
+
+    # permission denied at domain level
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    mailbox.refresh_from_db()
+    assert mailbox.secondary_email == saved_secondary
+
+
+def test_api_mailboxes_patch__unauthorized_no_mailbox():
+    """Authenticated but unauthoriezd users should not be able to update mailboxes."""
+    client = APIClient()
+    client.force_login(core_factories.UserFactory())
+
+    domain = factories.MailDomainEnabledFactory()
+    response = client.patch(
+        f"/api/v1.0/mail-domains/{domain.slug}/mailboxes/nonexistent_mailbox_pk/",
+        {"something": "updated"},
+        format="json",
+    )
+
+    # permission denied at domain level
+    # the existence of the mailbox is not checked
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_api_mailboxes_patch__viewer_forbidden():
+    """User having viewer access on a domain should not be able to update
+    anything on a mailbox that's not theirs."""
+    viewer = core_factories.UserFactory()
+    mailbox = factories.MailboxFactory()
+    factories.MailDomainAccessFactory(
+        user=viewer,
+        domain=mailbox.domain,
+        role=enums.MailDomainRoleChoices.VIEWER,
+    )
+
+    client = APIClient()
+    client.force_login(viewer)
+
+    # should not be able to update any field
+    for field_name in [
+        "secondary_email",
+        "first_name",
+        "last_name",
+        "domain",
+        "local_part",
+    ]:
+        old_value = getattr(mailbox, field_name)
+        response = client.patch(
+            f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/",
+            {field_name: "something_else"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        mailbox.refresh_from_db()
+        assert getattr(mailbox, field_name) == old_value
+
+
+# UPDATABLE FIELDS : SECONDARY EMAIL FIRST NAME AND LAST NAME
+@pytest.mark.parametrize(
+    "role",
+    ["owner", "administrator"],
+)
+def test_api_mailboxes_patch__admins_can_update_mailboxes(role):
+    """Domain owners and admins should be allowed to update secondary email on a mailbox"""
+    mailbox = factories.MailboxFactory()
+    user = core_factories.UserFactory()
+    factories.MailDomainAccessFactory(
+        user=user,
+        domain=mailbox.domain,
+        role=role,
+    )
+
+    client = APIClient()
+    client.force_login(user)
+
+    valid_new_values = {
+        "secondary_email": "updated_mail@validformat.com",
+        "first_name": "Marsha",
+        "last_name": "Johnson",
+    }
+    for field_name in ["first_name", "last_name", "secondary_email"]:
+        getattr(mailbox, field_name)
+        response = client.patch(
+            f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/",
+            {field_name: valid_new_values[field_name]},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        mailbox.refresh_from_db()
+        assert getattr(mailbox, field_name) == valid_new_values[field_name]
+
+
+# DOMAIN AND LOCAL PART
+@pytest.mark.parametrize(
+    "role",
+    ["viewer", "owner", "administrator"],
+)
+def test_api_mailboxes_patch__no_updating_domain_or_local_part(role):
+    """Domain and local parts should not be updated."""
+    mailbox = factories.MailboxFactory()
+    user = core_factories.UserFactory()
+    if role == "viewer":
+        # viewer has similar privileges as admins on own mailbox
+        user = core_factories.UserFactory(
+            email=f"{mailbox.local_part}@{mailbox.domain}"
+        )
+    access = factories.MailDomainAccessFactory(
+        user=user,
+        domain=mailbox.domain,
+        role=role,
+    )
+
+    client = APIClient()
+    client.force_login(user)
+
+    other_domain = factories.MailDomainEnabledFactory()
+    local_part = mailbox.local_part
+    response = client.patch(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/",
+        {"local_part": "new.local.part", "domain": other_domain.name},
+        format="json",
+    )
+    assert response.status_code == status.HTTP_200_OK  # a 400 would be better
+    mailbox.refresh_from_db()
+    assert mailbox.local_part == local_part
+    assert mailbox.domain == access.domain

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_put.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_put.py
@@ -12,17 +12,22 @@ from mailbox_manager import enums, factories
 
 pytestmark = pytest.mark.django_db
 
+# PUT expects all the object's updatable fields.
+# We'll use this dict on all the following tests
+NEW_VALUES = {
+    "secondary_email": "marsha.p@social.us",
+    "first_name": "Marsha",
+    "last_name": "Johnson",
+}
+
 
 def test_api_mailboxes_put__anonymous_forbidden():
     """Anonymous users should not be able to update a mailbox."""
     mailbox = factories.MailboxFactory()
     saved_secondary = mailbox.secondary_email
-    APIClient().get(
-        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/"
-    )
-    response = APIClient().patch(
+    response = APIClient().put(
         f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/",
-        {"something": "updated"},
+        NEW_VALUES,
     )
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
@@ -39,7 +44,7 @@ def test_api_mailboxes_put__unauthorized_forbidden():
     saved_secondary = mailbox.secondary_email
     response = client.put(
         f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/",
-        {"something": "updated"},
+        NEW_VALUES,
         format="json",
     )
 
@@ -57,7 +62,7 @@ def test_api_mailboxes_put__unauthorized_no_mailbox():
     domain = factories.MailDomainEnabledFactory()
     response = client.put(
         f"/api/v1.0/mail-domains/{domain.slug}/mailboxes/nonexistent_mailbox_pk/",
-        {"something": "updated"},
+        NEW_VALUES,
         format="json",
     )
 
@@ -81,23 +86,17 @@ def test_api_mailboxes_put__viewer_forbidden():
     client.force_login(viewer)
 
     # should not be able to update any field
-    for field_name in [
-        "secondary_email",
-        "first_name",
-        "last_name",
-        "domain",
-        "local_part",
-    ]:
-        old_value = getattr(mailbox, field_name)
-        response = client.put(
-            f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/",
-            {field_name: "something_else"},
-            format="json",
-        )
+    # we only try one field as 403 is global in our implementation
+    old_value = mailbox.secondary_email
+    response = client.put(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/",
+        NEW_VALUES,
+        format="json",
+    )
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-        mailbox.refresh_from_db()
-        assert getattr(mailbox, field_name) == old_value
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    mailbox.refresh_from_db()
+    assert mailbox.secondary_email == old_value
 
 
 # UPDATABLE FIELDS : SECONDARY EMAIL, FIRST NAME AND LAST NAME
@@ -118,26 +117,43 @@ def test_api_mailboxes_put__admins_can_update_mailboxes(role):
     client = APIClient()
     client.force_login(user)
 
-    valid_new_values = {
-        "secondary_email": "marsha.p@social.us",
-        "first_name": "Marsha",
-        "last_name": "Johnson",
-    }
     response = client.put(
         f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/",
-        {
-            "first_name": valid_new_values["first_name"],
-            "last_name": valid_new_values["last_name"],
-            "secondary_email": valid_new_values["secondary_email"],
-        },
+        NEW_VALUES,
         format="json",
     )
     result = response.json()
     assert response.status_code == status.HTTP_200_OK
     mailbox.refresh_from_db()
-    assert result["first_name"] == valid_new_values["first_name"]
-    assert result["last_name"] == valid_new_values["last_name"]
-    assert result["secondary_email"] == valid_new_values["secondary_email"]
+    assert result["first_name"] == NEW_VALUES["first_name"]
+    assert result["last_name"] == NEW_VALUES["last_name"]
+    assert result["secondary_email"] == NEW_VALUES["secondary_email"]
+
+
+def test_api_mailboxes_put__viewer_can_update_own_mailbox():
+    """Domain owners and admins should be allowed to update secondary email on a mailbox"""
+    mailbox = factories.MailboxFactory()
+    user = core_factories.UserFactory(email=f"{mailbox.local_part}@{mailbox.domain}")
+    factories.MailDomainAccessFactory(
+        user=user,
+        domain=mailbox.domain,
+        role=enums.MailDomainRoleChoices.VIEWER,
+    )
+
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.put(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/",
+        NEW_VALUES,
+        format="json",
+    )
+    result = response.json()
+    assert response.status_code == status.HTTP_200_OK
+    mailbox.refresh_from_db()
+    assert result["first_name"] == NEW_VALUES["first_name"]
+    assert result["last_name"] == NEW_VALUES["last_name"]
+    assert result["secondary_email"] == NEW_VALUES["secondary_email"]
 
 
 # DOMAIN AND LOCAL PART
@@ -167,10 +183,10 @@ def test_api_mailboxes_put__no_updating_domain_or_local_part(role):
     old_local_part = mailbox.local_part
     response = client.put(
         f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/",
-        {"local_part": "new.local.part", "domain": other_domain.name},
+        {**NEW_VALUES, "local_part": "new.local.part", "domain": other_domain.name},
         format="json",
     )
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == status.HTTP_200_OK  # This should not be a 200
     mailbox.refresh_from_db()
     assert mailbox.local_part == old_local_part
     assert mailbox.domain == access.domain

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_put.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_put.py
@@ -1,0 +1,176 @@
+"""
+Unit tests for the mailbox API
+"""
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core import factories as core_factories
+
+from mailbox_manager import enums, factories
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_mailboxes_put__anonymous_forbidden():
+    """Anonymous users should not be able to update a mailbox."""
+    mailbox = factories.MailboxFactory()
+    saved_secondary = mailbox.secondary_email
+    APIClient().get(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/"
+    )
+    response = APIClient().patch(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/",
+        {"something": "updated"},
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    mailbox.refresh_from_db()
+    assert mailbox.secondary_email == saved_secondary
+
+
+def test_api_mailboxes_put__unauthorized_forbidden():
+    """Authenticated but unauthoriezd users should not be able to update mailboxes."""
+    client = APIClient()
+    client.force_login(core_factories.UserFactory())
+
+    mailbox = factories.MailboxFactory()
+    saved_secondary = mailbox.secondary_email
+    response = client.put(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/",
+        {"something": "updated"},
+        format="json",
+    )
+
+    # permission denied at domain level
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    mailbox.refresh_from_db()
+    assert mailbox.secondary_email == saved_secondary
+
+
+def test_api_mailboxes_put__unauthorized_no_mailbox():
+    """Authenticated but unauthoriezd users should not be able to update mailboxes."""
+    client = APIClient()
+    client.force_login(core_factories.UserFactory())
+
+    domain = factories.MailDomainEnabledFactory()
+    response = client.put(
+        f"/api/v1.0/mail-domains/{domain.slug}/mailboxes/nonexistent_mailbox_pk/",
+        {"something": "updated"},
+        format="json",
+    )
+
+    # permission denied at domain level
+    # the existence of the mailbox is not checked
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_api_mailboxes_put__viewer_forbidden():
+    """User having viewer access on a domain should not be able to update
+    anything on a mailbox that's not theirs."""
+    viewer = core_factories.UserFactory()
+    mailbox = factories.MailboxFactory()
+    factories.MailDomainAccessFactory(
+        user=viewer,
+        domain=mailbox.domain,
+        role=enums.MailDomainRoleChoices.VIEWER,
+    )
+
+    client = APIClient()
+    client.force_login(viewer)
+
+    # should not be able to update any field
+    for field_name in [
+        "secondary_email",
+        "first_name",
+        "last_name",
+        "domain",
+        "local_part",
+    ]:
+        old_value = getattr(mailbox, field_name)
+        response = client.put(
+            f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/",
+            {field_name: "something_else"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        mailbox.refresh_from_db()
+        assert getattr(mailbox, field_name) == old_value
+
+
+# UPDATABLE FIELDS : SECONDARY EMAIL, FIRST NAME AND LAST NAME
+@pytest.mark.parametrize(
+    "role",
+    ["owner", "administrator"],
+)
+def test_api_mailboxes_put__admins_can_update_mailboxes(role):
+    """Domain owners and admins should be allowed to update secondary email on a mailbox"""
+    mailbox = factories.MailboxFactory()
+    user = core_factories.UserFactory()
+    factories.MailDomainAccessFactory(
+        user=user,
+        domain=mailbox.domain,
+        role=role,
+    )
+
+    client = APIClient()
+    client.force_login(user)
+
+    valid_new_values = {
+        "secondary_email": "marsha.p@social.us",
+        "first_name": "Marsha",
+        "last_name": "Johnson",
+    }
+    response = client.put(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/",
+        {
+            "first_name": valid_new_values["first_name"],
+            "last_name": valid_new_values["last_name"],
+            "secondary_email": valid_new_values["secondary_email"],
+        },
+        format="json",
+    )
+    result = response.json()
+    assert response.status_code == status.HTTP_200_OK
+    mailbox.refresh_from_db()
+    assert result["first_name"] == valid_new_values["first_name"]
+    assert result["last_name"] == valid_new_values["last_name"]
+    assert result["secondary_email"] == valid_new_values["secondary_email"]
+
+
+# DOMAIN AND LOCAL PART
+@pytest.mark.parametrize(
+    "role",
+    ["viewer", "owner", "administrator"],
+)
+def test_api_mailboxes_put__no_updating_domain_or_local_part(role):
+    """Domain and local parts should not be updated."""
+    mailbox = factories.MailboxFactory()
+    user = core_factories.UserFactory()
+    if role == "viewer":
+        # viewer has similar privileges as admins on own mailbox
+        user = core_factories.UserFactory(
+            email=f"{mailbox.local_part}@{mailbox.domain}"
+        )
+    access = factories.MailDomainAccessFactory(
+        user=user,
+        domain=mailbox.domain,
+        role=role,
+    )
+
+    client = APIClient()
+    client.force_login(user)
+
+    other_domain = factories.MailDomainEnabledFactory()
+    old_local_part = mailbox.local_part
+    response = client.put(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/",
+        {"local_part": "new.local.part", "domain": other_domain.name},
+        format="json",
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    mailbox.refresh_from_db()
+    assert mailbox.local_part == old_local_part
+    assert mailbox.domain == access.domain

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_retrieve.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_retrieve.py
@@ -35,3 +35,47 @@ def test_api_mailboxes__retrieve_unauthorized_failure():
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
     # 403 or 404 for confidentiality/security purposes ?
+
+    # response should be the same whether the mailbox exists or not, so that
+    # unauthorized users can't deduce mailbox existence or nonexistence
+    response = client.get(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/thismailboxdoesntexist/"
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_api_mailboxes__retrieve_authorized_ok():
+    """Authorized users should be able to retrieve mailboxes."""
+
+    access = factories.MailDomainAccessFactory()
+    mailbox = factories.MailboxFactory(domain=access.domain)
+
+    client = APIClient()
+    client.force_login(access.user)
+    response = client.get(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "id": str(mailbox.id),
+        "first_name": mailbox.first_name,
+        "last_name": mailbox.last_name,
+        "local_part": mailbox.local_part,
+        "secondary_email": mailbox.secondary_email,
+        "status": mailbox.status,
+    }
+
+
+def test_api_mailboxes__owner_not_authorized():
+    """Unauthorized mailbox owner should not be able to retrieve their mailbox."""
+    mailbox = factories.MailboxFactory()
+    user = core_factories.UserFactory(email=str(mailbox))
+
+    client = APIClient()
+    client.force_login(user)
+    response = client.get(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/"
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_retrieve.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_retrieve.py
@@ -1,0 +1,37 @@
+"""
+Unit tests for the mailbox API
+"""
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core import factories as core_factories
+
+from mailbox_manager import factories
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_mailboxes__retrieve_anonymous_forbidden():
+    """Anonymous users should not be able to retrieve a new mailbox via the API."""
+    mailbox = factories.MailboxFactory()
+    response = APIClient().get(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/"
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_api_mailboxes__retrieve_unauthorized_failure():
+    """Authenticated but unauthorized users should not be able to
+    retrieve mailbox."""
+    client = APIClient()
+    client.force_login(core_factories.UserFactory())
+
+    mailbox = factories.MailboxFactory()
+    response = client.get(
+        f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/"
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    # 403 or 404 for confidentiality/security purposes ?


### PR DESCRIPTION
## Purpose

Allow update of mailboxes. Secondary email, first and last names can be updated but not
domain or local_part. Also introduces the notion of "self" in permissions, allowing for a
domain viewer to update their own mailbox.

## Proposal

Description...

- [x] add update to mailbox endpoint 
- [x] domain and local part cannot be updated
- [x] add `get_abilities` to handle permissions
- [x] introduce a notion of "self" linking a mailbox to a user having this very same email
- [x] allow a domain viewer to update their own mailbox (secondary email, first name and last name)
- [x] tests