### PR TITLE
🐛(webhook) fix error raised when no secret

### DIFF
--- a/src/backend/core/tests/utils/test_webhooks_matrix_client.py
+++ b/src/backend/core/tests/utils/test_webhooks_matrix_client.py
@@ -138,7 +138,7 @@ def test_matrix_webhook__override_secret_for_tchap():
     webhook = factories.TeamWebhookFactory(
         protocol=WebhookProtocolChoices.MATRIX,
         url="https://www.tchap.gouv.fr/#/room/room_id:home_server",
-        secret="secret-about-to-be-overridden",
+        secret=None,
     )
 
     # Mock successful responses

--- a/src/backend/core/utils/matrix.py
+++ b/src/backend/core/utils/matrix.py
@@ -34,9 +34,12 @@ class MatrixAPIClient:
     def get_headers(self, webhook):
         """Build header dict from webhook object."""
         headers = {"Content-Type": "application/json"}
-        token = webhook.secret if webhook.secret else None
         if "tchap.gouv.fr" in webhook.url:
             token = settings.TCHAP_ACCESS_TOKEN
+        elif webhook.secret:
+            token = webhook.secret
+        else:
+            raise ValueError("Please configure this webhook's secret access token.")
         headers["Authorization"] = f"Bearer {token}"
         return headers
 
@@ -58,9 +61,6 @@ class MatrixAPIClient:
     def join_room(self, webhook):
         """Accept invitation to the room. As of today, it is a mandatory step
         to make sure our account will be able to invite/remove users."""
-        if webhook.secret is None:
-            raise ValueError("Please configure this webhook's secret access token.")
-
         return session.post(
             f"{self._get_room_url(webhook.url)}/join",
             json={},


### PR DESCRIPTION
## Purpose

Our Tchap webhook contains no secret (as we use the provided dedicated access token).
This lead to an error upon trying to join rooms.

## Proposal

Description...

- [x] fix error in `join_room` method
- [x] fix matching test
