### PR TITLE
🐛(webhooks) fix InsecureRequestWarning from webhook calls

### DIFF
--- a/src/backend/core/utils/matrix.py
+++ b/src/backend/core/utils/matrix.py
@@ -65,7 +65,7 @@ class MatrixAPIClient:
             f"{self._get_room_url(webhook.url)}/join",
             json={},
             headers=self.get_headers(webhook),
-            verify=False,
+            verify=True,
             timeout=3,
         )
 
@@ -87,7 +87,7 @@ class MatrixAPIClient:
                 "reason": f"User added to team {webhook.team} on People",
             },
             headers=self.get_headers(webhook),
-            verify=False,
+            verify=True,
             timeout=3,
         )
 
@@ -120,7 +120,7 @@ class MatrixAPIClient:
                 "reason": f"User removed from team {webhook.team} on People",
             },
             headers=self.get_headers(webhook),
-            verify=False,
+            verify=True,
             timeout=3,
         )
 


### PR DESCRIPTION
## Purpose

Matrix webhook calls were unverified and caused a security warning. Setting option "verify" to "True" on related calls should help.


! In my local environment, I still receive a 405 Not allowed error from Nginx.
This is the response I get from my calls to https://tchap.gouv.fr
![image](https://github.com/user-attachments/assets/86ca6f12-2009-4af9-9a9f-332fef4dc7fe)

## Proposal

Description...

- [] item 1...
- [] item 2...
