### PR TITLE
🐛(dependencies) ignore redis during renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
       "enabled": false,
       "groupName": "ignored python dependencies",
       "matchManagers": ["pep621"],
-      "matchPackageNames": []
+      "matchPackageNames": ["redis"]
     },
     {
       "enabled": false,


### PR DESCRIPTION
## Purpose

EDIT : it seems the upgrade to redis 6.0.0 is now passing the CI ? and now ruff is making trouble ?

Renovate is still trying to upgrade Redis above 6.0.0, meaning the previous fix didn't work as intended. 
![image](https://github.com/user-attachments/assets/cd0c0972-3ad5-4663-ae28-b78ed3531534)

Renovate runs actions to auto-upgrade dependencies but redis>=6.0.0 breaks compatibility of several other packages. This commit set redis version for Renovate to stop trying to upgrade redis.
I suggest we set Renovate to ignore redis package for now, [as Antoine made for meet](https://github.com/suitenumerique/meet/pull/553/commits/ed3b718922cba73af07b01b11492ac9ea4a92f67)

## Proposal

Description...

- [] item 1...
- [] item 2...
