### PR TITLE
🐛(webhooks) fix special case for tchap integration

### DIFF
--- a/src/backend/core/tests/utils/test_webhooks_matrix_client.py
+++ b/src/backend/core/tests/utils/test_webhooks_matrix_client.py
@@ -230,6 +230,9 @@ def test_matrix_webhook__override_secret_for_tchap():
     headers = responses.calls[0].request.headers
     assert "TCHAP_TOKEN" in headers["Authorization"]
 
+    # Check correctly inferred base url from room_id
+    assert "matrix.home_server" in responses.calls[0].request.url
+
 
 ## KICK
 @responses.activate

--- a/src/backend/core/utils/matrix.py
+++ b/src/backend/core/utils/matrix.py
@@ -45,7 +45,7 @@ class MatrixAPIClient:
         """Returns room id from webhook url."""
         room_id = webhook_url.split("/room/")[1]
         base_url = room_id.split(":")[1]
-        if "tchap.gouv.fr" in webhook_url:
+        if "tchap.gouv.fr" in webhook_url and "i.tchap.gouv.fr" not in webhook_url:
             base_url = f"matrix.{base_url}"
         return f"https://{base_url}/_matrix/client/v3/rooms/{room_id}"
 


### PR DESCRIPTION
## Purpose

we want to use Tchap integration server for our own preprod but this server doesn't follow the same url naming convention as the other Tchap instances, so it requires a special treatment. This quick fix should do it.

