### PR TITLE
🐛(admin) fix read_only preventing mailbox creation in admin

### DIFF
--- a/src/backend/mailbox_manager/admin.py
+++ b/src/backend/mailbox_manager/admin.py
@@ -208,7 +208,7 @@ class MailboxAdmin(UserAdmin):
     list_display = ("__str__", "domain", "status", "updated_at")
     list_filter = ("status",)
     search_fields = ("local_part", "domain__name")
-    readonly_fields = ["updated_at", "local_part", "domain"]
+    readonly_fields = ["updated_at"]
 
     fieldsets = None
     add_fieldsets = (


### PR DESCRIPTION
## Purpose

removed read_only on "local_part" and "domain" which prevented admin user from creating mailboxes from admin


## Proposal

Description...

- [] item 1...
- [] item 2...
