### PR TITLE
🐛(domains) fix invitation instead of access for existing users

### DIFF
--- a/src/backend/mailbox_manager/tests/api/invitations/test_api_domain_invitations_create.py
+++ b/src/backend/mailbox_manager/tests/api/invitations/test_api_domain_invitations_create.py
@@ -11,7 +11,7 @@ from rest_framework.test import APIClient
 
 from core import factories as core_factories
 
-from mailbox_manager import enums, factories
+from mailbox_manager import enums, factories, models
 from mailbox_manager.api.client import serializers
 
 pytestmark = pytest.mark.django_db
@@ -141,6 +141,7 @@ def test_api_domain_invitations__should_not_create_duplicate_invitations():
     assert response.json()["__all__"] == [
         "Mail domain invitation with this Email address and Domain already exists."
     ]
+    assert models.MailDomainInvitation.objects.count() == 1  # and specifically, not 2
 
 
 def test_api_domain_invitations__should_not_invite_when_user_already_exists():
@@ -164,3 +165,6 @@ def test_api_domain_invitations__should_not_invite_when_user_already_exists():
     assert response.json()["email"] == [
         "This email is already associated to a registered user."
     ]
+
+    assert not models.MailDomainInvitation.objects.exists()
+    assert models.MailDomainAccess.objects.filter(user=existing_user).exists()


### PR DESCRIPTION
## Purpose

Users can only search other users inside their own organization. This leads to situations where 
- people are trying to share accesses to coworkers from other organization
- the back-end doesn't realize the person already exists
- sends an invite
- invite is never consumed because their account already exists 🙃 
See #859 

## Proposal

Description...

- [x] Fix tests
- [ ] Define if this is a back-end issue or a front-end issue (or both)
- [ ] Fix it
- [ ] manually "convert" potential pending invitations to accesses in prod