### PR TITLE
⬆️(django-lasuite) bump to version 0.0.11

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "django-cors-headers==4.7.0",
     "django-countries==7.6.1",
     "django-extensions==4.1",
-    "django-lasuite==0.0.10",
+    "django-lasuite==0.0.11",
     "django-oauth-toolkit==3.0.1",
     "django-parler==2.3",
     "django-redis==5.4.0",


### PR DESCRIPTION
## Purpose

This allows to accept JWE from new Proconnect introspection endpoint.


## Proposal

- [x] bump `django-lasuite` to version 0.0.11

