### PR TITLE
🐛(config) remove default sentry_dsn

### DIFF
--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -1067,7 +1067,7 @@ class Production(Base):
         },
     }
     SENTRY_DSN = values.Value(
-        "https://b72746c73d669421e7a8ccd3fab0fad2@sentry.incubateur.net/171",
+        None,
         environ_name="SENTRY_DSN",
     )
 


### PR DESCRIPTION
## Purpose

set default `SENTRY_DSN` value to None to avoid all outside deployments sending infos to our sentry instance.
