### PR TITLE
💥(sentry) remove `DJANGO_` before Sentry DSN env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- 💥(sentry) remove `DJANGO_` before Sentry DSN env variable #957
+
 ## [1.18.2] - 2025-07-03
 
 ### Fixed

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -74,7 +74,7 @@ class Base(Configuration):
     You may also want to override default configuration by setting the following environment
     variables:
 
-    * DJANGO_SENTRY_DSN
+    * SENTRY_DSN
     * DB_NAME
     * DB_HOST
     * DB_PASSWORD
@@ -341,7 +341,7 @@ class Base(Configuration):
     CORS_ALLOWED_ORIGIN_REGEXES = values.ListValue([])
 
     # Sentry
-    SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")
+    SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN", environ_prefix=None)
 
     # Easy thumbnails
     THUMBNAIL_EXTENSION = "webp"
@@ -1066,10 +1066,6 @@ class Production(Base):
             },
         },
     }
-    SENTRY_DSN = values.Value(
-        None,
-        environ_name="SENTRY_DSN",
-    )
 
 
 class Feature(Production):

--- a/src/helm/env.d/dev-keycloak/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/dev-keycloak/values.desk.yaml.gotmpl
@@ -18,7 +18,6 @@ backend:
     DJANGO_EMAIL_HOST: "maildev"
     DJANGO_EMAIL_PORT: 1025
     DJANGO_EMAIL_USE_SSL: False
-    DJANGO_SENTRY_DSN: null
     OIDC_RS_CLIENT_ID: people
     OIDC_RS_CLIENT_SECRET: ThisIsAnExampleKeyForDevPurposeOnly
     OIDC_RS_SIGNING_ALGO: RS256
@@ -52,6 +51,7 @@ backend:
     POSTGRES_USER: dinum
     POSTGRES_PASSWORD: pass
     REDIS_URL: redis://default:pass@redis-master:6379/1
+    SENTRY_DSN: null
     WEBMAIL_URL: "https://onestendev.yapasdewebmail.fr"
     MAIL_PROVISIONING_API_URL: "http://dimail:8000"
     MAIL_PROVISIONING_API_CREDENTIALS: changeme

--- a/src/helm/env.d/dev/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.desk.yaml.gotmpl
@@ -33,7 +33,6 @@ backend:
     DJANGO_EMAIL_HOST: "maildev"
     DJANGO_EMAIL_PORT: 1025
     DJANGO_EMAIL_USE_SSL: False
-    DJANGO_SENTRY_DSN: null
     OIDC_OP_JWKS_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/jwks
     OIDC_OP_AUTHORIZATION_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/authorize
     OIDC_OP_TOKEN_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/token
@@ -67,6 +66,7 @@ backend:
     POSTGRES_USER: dinum
     POSTGRES_PASSWORD: pass
     REDIS_URL: redis://default:pass@redis-master:6379/1
+    SENTRY_DSN: null
     WEBMAIL_URL: "https://onestendev.yapasdewebmail.fr"
     MAIL_PROVISIONING_API_URL: "http://dimail.127.0.0.1.nip.io"
     MAIL_PROVISIONING_API_CREDENTIALS:


### PR DESCRIPTION
## Purpose

Other "La Suite" projects don't have the "DJANGO_" prefix, so we align this project with others.


## Proposal

- [x] rename `DJANGO_SENTRY_DSN` to `SENTRY_DSN`
