### PR TITLE
💚(ci) fix changelog CI job

### DIFF
--- a/.github/workflows/people.yml
+++ b/.github/workflows/people.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check that the CHANGELOG has been modified in the current branch
-        run: git whatchanged --name-only --pretty="" origin/${{ github.event.pull_request.base.ref }}..HEAD | grep CHANGELOG
+        run: git log --name-only --pretty="" origin/${{ github.event.pull_request.base.ref }}..HEAD | grep CHANGELOG
 
   lint-changelog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Purpose

`git whatchanged` got nominated for removal and now requires an additional option to run, to confirm that we still use it.

@qbey should I send a quick mail or do you want to do it ?