### PR TITLE
🔒️(security) match organization email domains exactly

### DIFF
--- a/src/backend/core/migrations/0018_organization_domain_list_lowercase.py
+++ b/src/backend/core/migrations/0018_organization_domain_list_lowercase.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+
+def lowercase_domain_list(apps, schema_editor):
+    """Domains are case-insensitive: store them lowercased so exact matching works."""
+    Organization = apps.get_model("core", "Organization")
+    for organization in Organization.objects.exclude(domain_list=[]):
+        lowered = [domain.lower() for domain in organization.domain_list]
+        if lowered != organization.domain_list:
+            organization.domain_list = lowered
+            organization.save(update_fields=["domain_list"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0017_teamwebhook_protocol"),
+    ]
+
+    operations = [
+        migrations.RunPython(lowercase_domain_list, migrations.RunPython.noop),
+    ]

--- a/src/backend/core/migrations/0018_organization_domain_list_lowercase.py
+++ b/src/backend/core/migrations/0018_organization_domain_list_lowercase.py
@@ -3,8 +3,8 @@ from django.db import migrations
 
 def lowercase_domain_list(apps, schema_editor):
     """Domains are case-insensitive: store them lowercased so exact matching works."""
-    Organization = apps.get_model("core", "Organization")
-    for organization in Organization.objects.exclude(domain_list=[]):
+    organization_model = apps.get_model("core", "Organization")
+    for organization in organization_model.objects.exclude(domain_list=[]):
         lowered = [domain.lower() for domain in organization.domain_list]
         if lowered != organization.domain_list:
             organization.domain_list = lowered

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -297,9 +297,9 @@ class OrganizationManager(models.Manager):
 
         filters = models.Q()
         if registration_id:
-            filters |= models.Q(registration_id_list__icontains=registration_id)
+            filters |= models.Q(registration_id_list__contains=[registration_id])
         if domain:
-            filters |= models.Q(domain_list__icontains=domain)
+            filters |= models.Q(domain_list__contains=[domain.lower()])
 
         with suppress(self.model.DoesNotExist):
             # If there are several organizations, we must raise an error and fix the data
@@ -313,7 +313,10 @@ class OrganizationManager(models.Manager):
             ), True
 
         if domain:
-            return self.create(name=domain, domain_list=[domain], **kwargs), True
+            return (
+                self.create(name=domain, domain_list=[domain.lower()], **kwargs),
+                True,
+            )
 
         raise ValueError("Should never reach this point.")
 

--- a/src/backend/core/tests/authentication/test_backends.py
+++ b/src/backend/core/tests/authentication/test_backends.py
@@ -348,6 +348,52 @@ def test_authentication_getter_new_user_with_email_new_organization(monkeypatch)
     assert user.organization.registration_id_list == []
 
 
+def test_authentication_getter_new_user_domain_substring_new_organization(monkeypatch):
+    """
+    A user whose email domain is only a substring of a registered domain
+    must not be attached to that organization.
+    """
+    factories.OrganizationFactory(domain_list=["ville-montpellier.fr"])
+
+    klass = OIDCAuthenticationBackend()
+    email = "agent@ontpellier.fr"
+
+    def get_userinfo_mocked(*args):
+        return {"sub": "123", "email": email, "first_name": "Mal", "last_name": "Actor"}
+
+    monkeypatch.setattr(OIDCAuthenticationBackend, "get_userinfo", get_userinfo_mocked)
+
+    user = klass.get_or_create_user(
+        access_token="test-token", id_token=None, payload=None
+    )
+
+    assert user.organization is not None
+    assert user.organization.domain_list == ["ontpellier.fr"]
+    assert models.Organization.objects.count() == 2
+
+
+def test_authentication_getter_new_user_domain_case_insensitive(monkeypatch):
+    """
+    Domain matching stays case-insensitive, as email domains are.
+    """
+    organization = factories.OrganizationFactory(domain_list=["ville-montpellier.fr"])
+
+    klass = OIDCAuthenticationBackend()
+    email = "agent@VILLE-MONTPELLIER.FR"
+
+    def get_userinfo_mocked(*args):
+        return {"sub": "123", "email": email, "first_name": "Mal", "last_name": "Actor"}
+
+    monkeypatch.setattr(OIDCAuthenticationBackend, "get_userinfo", get_userinfo_mocked)
+
+    user = klass.get_or_create_user(
+        access_token="test-token", id_token=None, payload=None
+    )
+
+    assert user.organization == organization
+    assert models.Organization.objects.count() == 1
+
+
 @pytest.mark.parametrize(
     "registration_id_setting,expected_registration_id_list,expected_domain_list",
     [


### PR DESCRIPTION
## Purpose

Organization auto-assignment at login matched the email domain with `icontains`, a substring match. A user controlling a domain like `ontpellier.fr` was silently attached to an organization registered with `ville-montpellier.fr`. As a member of the victim tenant, the user could read its whole user directory, all member profile contacts and organization details.

## Proposal

- replace the two `icontains` filters in `OrganizationManager.get_or_create_from_user_claims` with exact array containment
- keep the matching case-insensitive, since email domains are: lowercase the incoming domain before matching and on organization creation
- add data migration `0018_organization_domain_list_lowercase` for existing stored domains
- add two regression tests in `core/tests/authentication/test_backends.py`:
  - a substring domain does not join the organization, a separate one is created
  - an uppercase domain still matches its organization